### PR TITLE
add setting for verbose cargo output

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -34,7 +34,7 @@ function provideBuilder() {
         if (atom.config.get('build-cargo.verbose')) {
           return [name, '--verbose'];
         } else {
-          return [name]
+          return [name];
         }
       };
 

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -30,19 +30,14 @@ function provideBuilder() {
 
     settings: function (path) {
       var cargoPath = atom.config.get('build-cargo.cargoPath');
-      var with_verbose = function (name) {
-        if (atom.config.get('build-cargo.verbose')) {
-          return [name, '--verbose'];
-        } else {
-          return [name];
-        }
-      };
+      let args = [];
+      atom.config.get('build-cargo.verbose') && args.push('--verbose');
 
       return [
         {
           name: 'Cargo: build',
           exec: cargoPath,
-          args: with_verbose('build'),
+          args: [ 'build' ].concat(args),
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',
@@ -52,21 +47,21 @@ function provideBuilder() {
         {
           name: 'Cargo: clean',
           exec: cargoPath,
-          args: with_verbose('clean'),
+          args: [ 'clean' ].concat(args),
           sh: false,
           errorMatch: []
         },
         {
           name: 'Cargo: update',
           exec: cargoPath,
-          args: with_verbose('update'),
+          args: [ 'update' ].concat(args),
           sh: false,
           errorMatch: []
         },
         {
           name: 'Cargo: test',
           exec: cargoPath,
-          args: with_verbose('test'),
+          args: [ 'test' ].concat(args),
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',
@@ -76,7 +71,7 @@ function provideBuilder() {
         {
           name: 'Cargo: run',
           exec: cargoPath,
-          args: with_verbose('run'),
+          args: [ 'run' ].concat(args),
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -14,7 +14,7 @@ module.exports.config = {
     type: 'boolean',
     default: false,
     order: 2
-  },
+  }
 };
 
 function provideBuilder() {

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -30,7 +30,7 @@ function provideBuilder() {
 
     settings: function (path) {
       var cargoPath = atom.config.get('build-cargo.cargoPath');
-      let args = [];
+      var args = [];
       atom.config.get('build-cargo.verbose') && args.push('--verbose');
 
       return [

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -7,7 +7,14 @@ module.exports.config = {
     type: 'string',
     default: 'cargo',
     order: 1
-  }
+  },
+  verbose: {
+    title: 'Verbose Cargo output',
+    description: 'Pass the --verbose flag to cargo',
+    type: 'boolean',
+    default: false,
+    order: 2
+  },
 };
 
 function provideBuilder() {
@@ -23,12 +30,19 @@ function provideBuilder() {
 
     settings: function (path) {
       var cargoPath = atom.config.get('build-cargo.cargoPath');
+      var with_verbose = function (name) {
+        if (atom.config.get('build-cargo.verbose')) {
+          return [name, '--verbose'];
+        } else {
+          return [name]
+        }
+      };
 
       return [
         {
           name: 'Cargo: build',
           exec: cargoPath,
-          args: [ 'build' ],
+          args: with_verbose('build'),
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',
@@ -38,21 +52,21 @@ function provideBuilder() {
         {
           name: 'Cargo: clean',
           exec: cargoPath,
-          args: [ 'clean' ],
+          args: with_verbose('clean'),
           sh: false,
           errorMatch: []
         },
         {
           name: 'Cargo: update',
           exec: cargoPath,
-          args: [ 'update' ],
+          args: with_verbose('update'),
           sh: false,
           errorMatch: []
         },
         {
           name: 'Cargo: test',
           exec: cargoPath,
-          args: [ 'test' ],
+          args: with_verbose('test'),
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',
@@ -62,7 +76,7 @@ function provideBuilder() {
         {
           name: 'Cargo: run',
           exec: cargoPath,
-          args: [ 'run' ],
+          args: with_verbose('run'),
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',


### PR DESCRIPTION
changing the setting unfortunately only takes effect AFTER re-choosing the cargo command. Probably because the command is not re-computed every time build is run, but only when choosing the command from the menu
