### PR TITLE
Enable Backtrace for `cargo test`

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -53,9 +53,11 @@ function provideBuilder() {
           name: 'Cargo: test',
           exec: cargoPath,
           args: [ 'test' ],
+          env: { RUST_BACKTRACE: '1' },
           sh: false,
           errorMatch: [
             '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',
+            'at (?<file>[^.\/][^\\/][^\\:]+):(?<line>\\d+)',
             'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
           ]
         },


### PR DESCRIPTION
- sets env var `$RUST_BACKTRACE=1`
- matches references to local files in the backtrace

NOTE: This could be further improved by making this configurable. I'll leave that to someone more experienced with atom packages. ;-)
