### PR TITLE
Handle error spans

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -53,7 +53,7 @@ export function provideBuilder() {
           args: [ 'build' ].concat(args),
           sh: false,
           errorMatch: [
-            '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(error):',
+            '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: \\d+:\\d+ )?(error):',
             'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
           ]
         },


### PR DESCRIPTION
rustc may output error spans ("error reaches from line1:col1 to line2:col2"), which must be handled in the regex so the location can be clicked again.

See https://github.com/rust-lang/rust/blob/6941b2569ae1643335462da5a70f1429bad2f2fb/src/libsyntax/codemap.rs#L806
