### PR TITLE
Don't show stack trace info in the cargo test output

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -98,7 +98,6 @@ export function provideBuilder() {
         {
           name: 'Cargo: test',
           exec: cargoPath,
-          env: { RUST_BACKTRACE: '1' },
           args: [ 'test' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -21,6 +21,13 @@ export const config = {
     type: 'boolean',
     default: false,
     order: 3
+  },
+  showBacktrace: {
+    title: 'Show backtrace information in tests',
+    description: 'Set environment variable RUST_BACKTRACE=1',
+    type: 'boolean',
+    default: false,
+    order: 4
   }
 };
 
@@ -46,6 +53,11 @@ export function provideBuilder() {
       const docArgs = [ 'doc' ];
       atom.config.get('build-cargo.openDocs') && docArgs.push('--open');
 
+      const env = {};
+      if (atom.config.get('build-cargo.showBacktrace')) {
+        env['RUST_BACKTRACE'] = '1'
+      }
+
       const matchRelaxed = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: \\d+:\\d+ )?(error):';
       const matchStrict = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: \\d+:\\d+ )?';
       const matchThreadPanic = 'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)';
@@ -55,6 +67,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: build (debug)',
           exec: cargoPath,
+          env: env,
           args: [ 'build' ].concat(args),
           sh: false,
           errorMatch: [ matchRelaxed, matchThreadPanic ]
@@ -62,6 +75,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: build (release)',
           exec: cargoPath,
+          env: env,
           args: [ 'build', '--release' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic ]
@@ -69,6 +83,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: bench',
           exec: cargoPath,
+          env: env,
           args: [ 'bench' ].concat(args),
           sh: false,
           errorMatch: [ matchRelaxed, matchThreadPanic ]
@@ -76,6 +91,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: clean',
           exec: cargoPath,
+          env: env,
           args: [ 'clean' ].concat(args),
           sh: false,
           errorMatch: []
@@ -83,6 +99,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: doc',
           exec: cargoPath,
+          env: env,
           args: docArgs.concat(args),
           sh: false,
           errorMatch: []
@@ -90,7 +107,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: run',
           exec: cargoPath,
-          env: { RUST_BACKTRACE: '1' },
+          env: env,
           args: [ 'run' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
@@ -98,6 +115,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: test',
           exec: cargoPath,
+          env: env,
           args: [ 'test' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
@@ -105,6 +123,7 @@ export function provideBuilder() {
         {
           name: 'Cargo: update',
           exec: cargoPath,
+          env: env,
           args: [ 'update' ].concat(args),
           sh: false,
           errorMatch: []
@@ -112,6 +131,7 @@ export function provideBuilder() {
         {
           name: `Cargo: build example`,
           exec: cargoPath,
+          env: env,
           args: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
           errorMatch: [ matchRelaxed, matchThreadPanic ]
@@ -119,7 +139,7 @@ export function provideBuilder() {
         {
           name: `Cargo: run example`,
           exec: cargoPath,
-          env: { RUST_BACKTRACE: '1' },
+          env: env,
           args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]


### PR DESCRIPTION
The general case for testing is to check for failures vs successes, with information about what failed given by a call to something like `assert!`. Stack trace information can be useful but often isn't.
