### PR TITLE
pass full spans down to atom-build so the linter can show it properly

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -58,8 +58,8 @@ export function provideBuilder() {
         env['RUST_BACKTRACE'] = '1'
       }
 
-      const matchRelaxed = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: \\d+:\\d+ )?(error):';
-      const matchStrict = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: \\d+:\\d+ )?';
+      const matchRelaxed = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+) )?(error):';
+      const matchStrict = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+) )?';
       const matchThreadPanic = 'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)';
       const matchBacktrace = 'at (?<file>[^.\/][^\\/][^\\:]+):(?<line>\\d+)';
 


### PR DESCRIPTION
depends on https://github.com/noseglid/atom-build/pull/369 to do something useful
