### PR TITLE
Add support for `cargo check` and `cargo clippy`

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -29,6 +29,21 @@ export const config = {
     default: false,
     order: 4
   }
+  cargoCheck: {
+    title: 'Enable `cargo check',
+    description: 'Enable the `cargo check` Cargo command. Only use this if you have `cargo check` installed.',
+    type: 'boolean',
+    default: false,
+    order: 4
+  }
+  cargoClippy: {
+    title: 'Enable `cargo clippy',
+    description: 'Enable the `cargo clippy` Cargo command to run Clippy\'s lints. \
+                  Only use this if you have the `cargo clippy` package installed.',
+    type: 'boolean',
+    default: false,
+    order: 4
+  }
 };
 
 export function provideBuilder() {

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -34,7 +34,7 @@ export const config = {
     description: 'Enable the `cargo check` Cargo command. Only use this if you have `cargo check` installed.',
     type: 'boolean',
     default: false,
-    order: 4
+    order: 5
   }
   cargoClippy: {
     title: 'Enable `cargo clippy',
@@ -42,7 +42,7 @@ export const config = {
                   Only use this if you have the `cargo clippy` package installed.',
     type: 'boolean',
     default: false,
-    order: 4
+    order: 6
   }
 };
 

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -28,14 +28,14 @@ export const config = {
     type: 'boolean',
     default: false,
     order: 4
-  }
+  },
   cargoCheck: {
     title: 'Enable `cargo check',
     description: 'Enable the `cargo check` Cargo command. Only use this if you have `cargo check` installed.',
     type: 'boolean',
     default: false,
     order: 5
-  }
+  },
   cargoClippy: {
     title: 'Enable `cargo clippy',
     description: 'Enable the `cargo clippy` Cargo command to run Clippy\'s lints. \

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -78,7 +78,7 @@ export function provideBuilder() {
       const matchThreadPanic = 'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)';
       const matchBacktrace = 'at (?<file>[^.\/][^\\/][^\\:]+):(?<line>\\d+)';
 
-      return [
+      var commands = [
         {
           name: 'Cargo: build (debug)',
           exec: cargoPath,
@@ -160,6 +160,8 @@ export function provideBuilder() {
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
         }
       ];
+      
+      return commands;
     }
   };
 }

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -161,6 +161,28 @@ export function provideBuilder() {
         }
       ];
       
+      if (atom.config.get('build-cargo.cargoClippy')) {
+        commands.push({
+          name: `Cargo: Clippy`,
+          exec: cargoPath,
+          env: env,
+          args: ['clippy'].concat(args),
+          sh: false,
+          errorMatch: [ matchRelaxed, matchThreadPanic ]
+        })
+      }
+      
+      if (atom.config.get('build-cargo.cargoCheck')) {
+        commands.push({
+          name: `Cargo: check`,
+          exec: cargoPath,
+          env: env,
+          args: ['check'].concat(args),
+          sh: false,
+          errorMatch: [ matchRelaxed, matchThreadPanic ]
+        })
+      }
+      
       return commands;
     }
   };


### PR DESCRIPTION
This PR adds support for the third-party `cargo check` and `cargo clippy` subcommands. The [ `cargo check`](https://github.com/hawkw/atom-build-cargo) subcommand runs only the analysis stages of compilation and doesn't output a binary, which can be useful when building a project takes a very long time. The [ `cargo clippy`](https://github.com/White-Oak/cargo-clippy) subcommand runs the popular [Clippy](https://github.com/Manishearth/rust-clippy) linter on the project.

Right now, both of these commands can be enabled by configuration options in the linter's settings page. These options should only be checked if the corresponding Cargo subcommand is installed. Eventually, I'd like to detect installed third-party subcommands automatically by trying to run the subcommand and parsing the console output to see if there's a "no such subcommand" error, but this works just fine for now. I'd also eventually like to add support for passing additional config options to Clippy (which the `cargo clippy` subcommand supports).

Please let me know if you have any questions about this PR or encounter any issues!
