### PR TITLE
Add support for `cargo run --bin`

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -143,6 +143,14 @@ export function provideBuilder() {
           args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
+        },
+        {
+          name: `Cargo: run bin`,
+          exec: cargoPath,
+          env: env,
+          args: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
+          sh: false,
+          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
         }
       ];
     }


### PR DESCRIPTION
This PR adds support for running named bin target via `cargo run --bin`.
