### PR TITLE
Add support for Atom commands and `cargo run --release`

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -154,13 +154,22 @@ export function provideBuilder() {
           atomCommandName: "cargo:doc"
         },
         {
-          name: 'Cargo: run',
+          name: 'Cargo: run (debug)',
           exec: cargoPath,
           env: env,
           args: [ 'run' ].concat(args),
           sh: false,
           errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ],
-          atomCommandName: "cargo:run"
+          atomCommandName: "cargo:run-debug"
+        },
+        {
+          name: 'Cargo: run (release)',
+          exec: cargoPath,
+          env: env,
+          args: [ 'run', '--release' ].concat(args),
+          sh: false,
+          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ],
+          atomCommandName: "cargo:run-release"
         },
         {
           name: 'Cargo: test',

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -114,7 +114,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'build' ].concat(args),
           sh: false,
-          errorMatch: [ matchRelaxed, matchThreadPanic ]
+          errorMatch: [ matchRelaxed, matchThreadPanic ],
+          atomCommandName: "cargo:build-debug"
         },
         {
           name: 'Cargo: build (release)',
@@ -122,7 +123,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'build', '--release' ].concat(args),
           sh: false,
-          errorMatch: [ matchStrict, matchThreadPanic ]
+          errorMatch: [ matchStrict, matchThreadPanic ],
+          atomCommandName: "cargo:build-release"
         },
         {
           name: 'Cargo: bench',
@@ -130,7 +132,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'bench' ].concat(args),
           sh: false,
-          errorMatch: [ matchRelaxed, matchThreadPanic ]
+          errorMatch: [ matchRelaxed, matchThreadPanic ],
+          atomCommandName: "cargo:bench"
         },
         {
           name: 'Cargo: clean',
@@ -138,7 +141,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'clean' ].concat(args),
           sh: false,
-          errorMatch: []
+          errorMatch: [],
+          atomCommandName: "cargo:clean"
         },
         {
           name: 'Cargo: doc',
@@ -146,7 +150,8 @@ export function provideBuilder() {
           env: env,
           args: docArgs.concat(args),
           sh: false,
-          errorMatch: []
+          errorMatch: [],
+          atomCommandName: "cargo:doc"
         },
         {
           name: 'Cargo: run',
@@ -154,7 +159,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run' ].concat(args),
           sh: false,
-          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
+          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ],
+          atomCommandName: "cargo:run"
         },
         {
           name: 'Cargo: test',
@@ -162,7 +168,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'test' ].concat(args),
           sh: false,
-          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
+          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ],
+          atomCommandName: "cargo:run-test"
         },
         {
           name: 'Cargo: update',
@@ -170,7 +177,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'update' ].concat(args),
           sh: false,
-          errorMatch: []
+          errorMatch: [],
+          atomCommandName: "cargo:update"
         },
         {
           name: `Cargo: build example`,
@@ -178,7 +186,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: [ matchRelaxed, matchThreadPanic ]
+          errorMatch: [ matchRelaxed, matchThreadPanic ],
+          atomCommandName: "cargo:build-example"
         },
         {
           name: `Cargo: run example`,
@@ -186,7 +195,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
+          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ],
+          atomCommandName: "cargo:run-example"
         },
         {
           name: `Cargo: run bin`,
@@ -194,7 +204,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ]
+          errorMatch: [ matchStrict, matchThreadPanic, matchBacktrace ],
+          atomCommandName: "cargo:run-bin"
         }
       ];
 
@@ -205,7 +216,8 @@ export function provideBuilder() {
           env: env,
           args: ['clippy'].concat(args),
           sh: false,
-          errorMatch: [ matchRelaxed, matchThreadPanic ]
+          errorMatch: [ matchRelaxed, matchThreadPanic ],
+          atomCommandName: "cargo:clippy"
         })
       }
 
@@ -216,7 +228,8 @@ export function provideBuilder() {
           env: env,
           args: ['check'].concat(args),
           sh: false,
-          errorMatch: [ matchRelaxed, matchThreadPanic ]
+          errorMatch: [ matchRelaxed, matchThreadPanic ],
+          atomCommandName: "cargo:check"
         })
       }
 


### PR DESCRIPTION
This PR adds Atom commands(useful for binding build actions to toolbars) and support for running program in release mode.
