### PR TITLE
also match on warnings when running clippy

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -267,7 +267,7 @@ export function provideBuilder() {
           env: env,
           args: ['clippy'].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchRelaxed, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchStrict, matchThreadPanic ],
           functionMatch: matchFunction,
           atomCommandName: 'cargo:clippy'
         });


### PR DESCRIPTION
Clippy mostly only produces warnings, not errors.
