### PR TITLE
Add support for Atom Build warnings

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -82,8 +82,9 @@ export function provideBuilder() {
         env.RUST_BACKTRACE = '1';
       }
 
-      const matchRelaxed = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+) )?(error): (?<message>[^\n]+)';
-      const matchStrict = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+) )?(?<message>[^\n]+)';
+      const matchError = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+))? error: (?<message>[^\n]+)';
+      const matchWarning = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+))? (warning|note|help): (?<message>[^\n]+)';
+
       const matchFunction = atom.config.get('build-cargo.jsonErrors') && function (output) {
         const array = [];
         function level2severity(level) {
@@ -91,6 +92,7 @@ export function provideBuilder() {
             case 'warning': return 'warning';
             case 'error': return 'error';
             case 'note': return 'info';
+            case 'help': return 'info';
             default: return 'error';
           }
         }
@@ -147,7 +149,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'build' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchRelaxed, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-debug'
         },
@@ -157,7 +160,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'build', '--release' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchStrict, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-release'
         },
@@ -167,7 +171,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'bench' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchRelaxed, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:bench'
         },
@@ -195,7 +200,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [ matchThreadPanic, matchBacktrace ] : [ matchStrict, matchThreadPanic, matchBacktrace ],
+          errorMatch: matchFunction ? [ matchThreadPanic, matchBacktrace ] : [ matchError, matchThreadPanic, matchBacktrace ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-debug'
         },
@@ -205,7 +211,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--release' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [ matchThreadPanic, matchBacktrace ] : [ matchStrict, matchThreadPanic, matchBacktrace ],
+          errorMatch: matchFunction ? [ matchThreadPanic, matchBacktrace ] : [ matchError, matchThreadPanic, matchBacktrace ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-release'
         },
@@ -215,7 +222,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'test' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchStrict, matchThreadPanic, matchBacktrace ],
+          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchError, matchThreadPanic, matchBacktrace ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-test'
         },
@@ -234,7 +242,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchRelaxed, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-example'
         },
@@ -244,7 +253,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchRelaxed, matchThreadPanic, matchBacktrace ],
+          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchError, matchThreadPanic, matchBacktrace ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-example'
         },
@@ -254,7 +264,8 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchRelaxed, matchThreadPanic, matchBacktrace ],
+          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchError, matchThreadPanic, matchBacktrace ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-bin'
         }
@@ -267,7 +278,8 @@ export function provideBuilder() {
           env: env,
           args: ['clippy'].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchRelaxed, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:clippy'
         });
@@ -280,7 +292,8 @@ export function provideBuilder() {
           env: env,
           args: ['check'].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchRelaxed, matchThreadPanic ],
+          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
+          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:check'
         });


### PR DESCRIPTION
I've added support for Atom Build's warnings. Instead of emitting errors for all the types of rustc messages, the plugin now produces warnings for `warning`, `note` and `help` messages.

fixes #37 
