### PR TITLE
Output parsing enhancement

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -82,65 +82,130 @@ export function provideBuilder() {
         env.RUST_BACKTRACE = '1';
       }
 
-      const matchError = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+))? error: (?<message>[^\n]+)';
-      const matchWarning = '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):(?: (?<line_end>\\d+):(?<col_end>\\d+))? (warning|note|help): (?<message>[^\n]+)';
+      function matchFunction(output) {
+        const useJson = atom.config.get('build-cargo.jsonErrors');
+        const messages = [];  // resulting collection of high-level messages
+        var msg = null;       // current high-level message (error, warning or panic)
+        var sub = null;       // current submessage (note or help)
 
-      const matchFunction = atom.config.get('build-cargo.jsonErrors') && function (output) {
-        const array = [];
-        function level2severity(level) {
-          switch (level) {
-            case 'warning': return 'warning';
-            case 'error': return 'error';
-            case 'note': return 'info';
-            case 'help': return 'info';
-            default: return 'error';
-          }
-        }
         output.split(/\n/).forEach(line => {
-          if (line[0] !== '{') {
-            return;
+          // Cargo final error messages start with 'error:', skip them
+          if (line == null || line == "" || line.substring(0, 6) == 'error:') {
+            msg = null;
+            sub = null;
+          } else if (useJson && line[0] === '{') {
+            // Parse a JSON block
+            parseJsonOutput(line, messages);
+          } else if (line.substring(0, 16) == 'stack backtrace:') {
+            // Start a stacktrace submessage (it's always under a panic message)
+            if (msg != null) {
+              sub = {
+                message: 'Stack backtrace',
+                type: 'Stack'
+              };
+              msg.trace.push(sub);
+            }
+          } else {
+            // Check for compilation messages
+            var match = /^(.+.rs):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
+            if (match) {
+              const type = match[6];
+              const message = match[7];
+              if (type == 'error' || type == 'warning' || msg == null) {
+                msg = {
+                  message: message,
+                  file: match[1],
+                  line: match[2],
+                  line_end: match[4],
+                  col: match[3],
+                  col_end: match[5],
+                  type: type,
+                  trace: []
+                };
+                messages.push(msg);
+                sub = null;
+              } else {
+                sub = {
+                  message: message,
+                  type: 'info'
+                }
+                msg.trace.push(sub);
+              }
+            } else {
+              // Check for panic
+              match = /^(thread '[^']+' panicked at '[^']+'), ([^\/][^\:]+):(\d+)/g.exec(line);
+              if (match) {
+                msg = {
+                  message: match[1],
+                  file: match[2],
+                  line: match[3],
+                  type: 'error',
+                  trace: []
+                };
+                messages.push(msg);
+                sub = null;
+              } else {
+                // Just a description in the current block. Only add it when in submessage
+                // because Linter does the job for high-level messages.
+                if (sub != null) {
+                  sub.message += '\n' + line;
+                }
+              }
+            }
           }
-          const json = JSON.parse(line);
-          const trace = [];
-          json.children.forEach(child => {
-            child.spans.forEach(span => {
-              trace.push({
-                message: child.message,
-                file: span.file_name,
-                line: span.line_start,
-                line_end: span.line_end,
-                col: span.column_start,
-                col_end: span.column_end,
-                type: 'Trace', // FIXME: change to `child.level` after https://github.com/steelbrain/linter/issues/1149 is fixed
-                severity: level2severity(json.level)
-              });
-            });
-          });
-          if (json.code) {
+        });
+        return messages;
+      }
+
+      // Parses json output
+      function parseJsonOutput(line, messages) {
+        const json = JSON.parse(line);
+        const trace = [];
+        json.children.forEach(child => {
+          child.spans.forEach(span => {
             trace.push({
-              message: json.code.explanation,
-              type: 'Explanation',
-              severity: 'info'
-            });
-          }
-          json.spans.forEach(span => {
-            array.push({
-              message: json.message,
+              message: child.message,
               file: span.file_name,
               line: span.line_start,
               line_end: span.line_end,
               col: span.column_start,
               col_end: span.column_end,
-              type: json.level, // FIXME: change to `json.code ? json.code : json.level` after https://github.com/steelbrain/linter/issues/1149 is fixed
-              severity: level2severity(json.level),
-              trace: trace
+              type: 'Trace', // FIXME: change to `child.level` after https://github.com/steelbrain/linter/issues/1149 is fixed
+              severity: level2severity(json.level)
             });
           });
         });
-        return array;
+        if (json.code) {
+          trace.push({
+            message: json.code.explanation,
+            type: 'Explanation',
+            severity: 'info'
+          });
+        }
+        json.spans.forEach(span => {
+          messages.push({
+            message: json.message,
+            file: span.file_name,
+            line: span.line_start,
+            line_end: span.line_end,
+            col: span.column_start,
+            col_end: span.column_end,
+            type: json.level, // FIXME: change to `json.code ? json.code : json.level` after https://github.com/steelbrain/linter/issues/1149 is fixed
+            severity: level2severity(json.level),
+            trace: trace
+          });
+        });
       };
-      const matchThreadPanic = 'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)';
-      const matchBacktrace = 'at (?<file>[^.\/][^\\/][^\\:]+):(?<line>\\d+)';
+
+      function level2severity(level) {
+        switch (level) {
+          case 'warning': return 'warning';
+          case 'error': return 'error';
+          case 'note': return 'info';
+          case 'help': return 'info';
+          default: return 'error';
+        }
+      }
 
       const commands = [
         {
@@ -149,8 +214,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'build' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-debug'
         },
@@ -160,8 +223,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'build', '--release' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-release'
         },
@@ -171,8 +232,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'bench' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:bench'
         },
@@ -200,8 +259,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'run' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [ matchThreadPanic, matchBacktrace ] : [ matchError, matchThreadPanic, matchBacktrace ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-debug'
         },
@@ -211,8 +268,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--release' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [ matchThreadPanic, matchBacktrace ] : [ matchError, matchThreadPanic, matchBacktrace ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-release'
         },
@@ -222,8 +277,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'test' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchError, matchThreadPanic, matchBacktrace ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-test'
         },
@@ -242,8 +295,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-example'
         },
@@ -253,8 +304,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchError, matchThreadPanic, matchBacktrace ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-example'
         },
@@ -264,8 +313,6 @@ export function provideBuilder() {
           env: env,
           args: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
-          errorMatch: matchFunction ? [matchThreadPanic, matchBacktrace] : [ matchError, matchThreadPanic, matchBacktrace ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-bin'
         }
@@ -278,8 +325,6 @@ export function provideBuilder() {
           env: env,
           args: ['clippy'].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:clippy'
         });
@@ -292,8 +337,6 @@ export function provideBuilder() {
           env: env,
           args: ['check'].concat(args),
           sh: false,
-          errorMatch: matchFunction ? matchThreadPanic : [ matchError, matchThreadPanic ],
-          warningMatch: matchWarning,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:check'
         });

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -82,79 +82,14 @@ export function provideBuilder() {
         env.RUST_BACKTRACE = '1';
       }
 
-      function matchFunction(output) {
-        const useJson = atom.config.get('build-cargo.jsonErrors');
-        const messages = [];  // resulting collection of high-level messages
-        var msg = null;       // current high-level message (error, warning or panic)
-        var sub = null;       // current submessage (note or help)
-
-        output.split(/\n/).forEach(line => {
-          // Cargo final error messages start with 'error:', skip them
-          if (line == null || line == "" || line.substring(0, 6) == 'error:') {
-            msg = null;
-            sub = null;
-          } else if (useJson && line[0] === '{') {
-            // Parse a JSON block
-            parseJsonOutput(line, messages);
-          } else if (line.substring(0, 16) == 'stack backtrace:') {
-            // Start a stacktrace submessage (it's always under a panic message)
-            if (msg != null) {
-              sub = {
-                message: 'Stack backtrace',
-                type: 'Stack'
-              };
-              msg.trace.push(sub);
-            }
-          } else {
-            // Check for compilation messages
-            var match = /^(.+.rs):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
-            if (match) {
-              const type = match[6];
-              const message = match[7];
-              if (type == 'error' || type == 'warning' || msg == null) {
-                msg = {
-                  message: message,
-                  file: match[1],
-                  line: match[2],
-                  line_end: match[4],
-                  col: match[3],
-                  col_end: match[5],
-                  type: type,
-                  trace: []
-                };
-                messages.push(msg);
-                sub = null;
-              } else {
-                sub = {
-                  message: message,
-                  type: 'info'
-                }
-                msg.trace.push(sub);
-              }
-            } else {
-              // Check for panic
-              match = /^(thread '[^']+' panicked at '[^']+'), ([^\/][^\:]+):(\d+)/g.exec(line);
-              if (match) {
-                msg = {
-                  message: match[1],
-                  file: match[2],
-                  line: match[3],
-                  type: 'error',
-                  trace: []
-                };
-                messages.push(msg);
-                sub = null;
-              } else {
-                // Just a description in the current block. Only add it when in submessage
-                // because Linter does the job for high-level messages.
-                if (sub != null) {
-                  sub.message += '\n' + line;
-                }
-              }
-            }
-          }
-        });
-        return messages;
+      function level2severity(level) {
+        switch (level) {
+          case 'warning': return 'warning';
+          case 'error': return 'error';
+          case 'note': return 'info';
+          case 'help': return 'info';
+          default: return 'error';
+        }
       }
 
       // Parses json output
@@ -195,16 +130,82 @@ export function provideBuilder() {
             trace: trace
           });
         });
-      };
+      }
 
-      function level2severity(level) {
-        switch (level) {
-          case 'warning': return 'warning';
-          case 'error': return 'error';
-          case 'note': return 'info';
-          case 'help': return 'info';
-          default: return 'error';
-        }
+      function matchFunction(output) {
+        const useJson = atom.config.get('build-cargo.jsonErrors');
+        const messages = [];  // resulting collection of high-level messages
+        let msg = null;       // current high-level message (error, warning or panic)
+        let sub = null;       // current submessage (note or help)
+        let match = null;
+
+        output.split(/\n/).forEach(line => {
+          // Cargo final error messages start with 'error:', skip them
+          if (line === null || line === '' || line.substring(0, 6) === 'error:') {
+            msg = null;
+            sub = null;
+          } else if (useJson && line[0] === '{') {
+            // Parse a JSON block
+            parseJsonOutput(line, messages);
+          } else if (line.substring(0, 16) === 'stack backtrace:') {
+            // Start a stacktrace submessage (it's always under a panic message)
+            if (msg !== null) {
+              sub = {
+                message: 'Stack backtrace',
+                type: 'Stack'
+              };
+              msg.trace.push(sub);
+            }
+          } else {
+            // Check for compilation messages
+            match = /^(.+.rs):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
+            if (match) {
+              const type = match[6];
+              const message = match[7];
+              if (type === 'error' || type === 'warning' || msg === null) {
+                msg = {
+                  message: message,
+                  file: match[1],
+                  line: match[2],
+                  line_end: match[4],
+                  col: match[3],
+                  col_end: match[5],
+                  type: type,
+                  trace: []
+                };
+                messages.push(msg);
+                sub = null;
+              } else {
+                sub = {
+                  message: message,
+                  type: 'info'
+                };
+                msg.trace.push(sub);
+              }
+            } else {
+              // Check for panic
+              match = /^(thread '[^']+' panicked at '[^']+'), ([^\/][^\:]+):(\d+)/g.exec(line);
+              if (match) {
+                msg = {
+                  message: match[1],
+                  file: match[2],
+                  line: match[3],
+                  type: 'error',
+                  trace: []
+                };
+                messages.push(msg);
+                sub = null;
+              } else {
+                // Just a description in the current block. Only add it when in submessage
+                // because Linter does the job for high-level messages.
+                if (sub !== null) {
+                  sub.message += '\n' + line;
+                }
+              }
+            }
+          }
+        });
+        return messages;
       }
 
       const commands = [

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -92,22 +92,33 @@ export function provideBuilder() {
         }
       }
 
+      function level2type(level) {
+        // FIXME: Should be changed to the following code when Linter starts respect
+        // severity while setting the message lable color (see https://github.com/steelbrain/linter/issues/1149):
+        // return level.charAt(0).toUpperCase() + level.slice(1);
+        switch (level) {
+          case 'warning': return 'Warning';
+          case 'error': return 'Error';
+          case 'note': return 'Info';
+          case 'help': return 'Info';
+          default: return 'Error';
+        }
+      }
+
       // Parses json output
       function parseJsonOutput(line, messages) {
         const json = JSON.parse(line);
         const trace = [];
-        json.children.forEach(child => {
-          child.spans.forEach(span => {
-            trace.push({
-              message: child.message,
-              file: span.file_name,
-              line: span.line_start,
-              line_end: span.line_end,
-              col: span.column_start,
-              col_end: span.column_end,
-              type: 'Trace', // FIXME: change to `child.level` after https://github.com/steelbrain/linter/issues/1149 is fixed
-              severity: level2severity(json.level)
-            });
+        json.spans.forEach(span => {
+          trace.push({
+            message: span.label,
+            file: span.file_name,
+            line: span.line_start,
+            line_end: span.line_end,
+            col: span.column_start,
+            col_end: span.column_end,
+            type: level2type('note'),
+            severity: level2severity('note')
           });
         });
         if (json.code) {
@@ -125,7 +136,7 @@ export function provideBuilder() {
             line_end: span.line_end,
             col: span.column_start,
             col_end: span.column_end,
-            type: json.level, // FIXME: change to `json.code ? json.code : json.level` after https://github.com/steelbrain/linter/issues/1149 is fixed
+            type: level2type(json.level),
             severity: level2severity(json.level),
             trace: trace
           });
@@ -160,9 +171,9 @@ export function provideBuilder() {
             // Check for compilation messages
             match = /^(.+.rs):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
             if (match) {
-              const type = match[6];
+              const level = match[6];
               const message = match[7];
-              if (type === 'error' || type === 'warning' || msg === null) {
+              if (level === 'error' || level === 'warning' || msg === null) {
                 msg = {
                   message: message,
                   file: match[1],
@@ -170,7 +181,8 @@ export function provideBuilder() {
                   line_end: match[4],
                   col: match[3],
                   col_end: match[5],
-                  type: type,
+                  type: level2type(level),
+                  severity: level2severity(level),
                   trace: []
                 };
                 messages.push(msg);
@@ -178,7 +190,13 @@ export function provideBuilder() {
               } else {
                 sub = {
                   message: message,
-                  type: 'info'
+                  file: match[1],
+                  line: match[2],
+                  line_end: match[4],
+                  col: match[3],
+                  col_end: match[5],
+                  type: level2type(level),
+                  severity: level2severity(level)
                 };
                 msg.trace.push(sub);
               }
@@ -190,17 +208,16 @@ export function provideBuilder() {
                   message: match[1],
                   file: match[2],
                   line: match[3],
-                  type: 'error',
+                  type: 'Error',
+                  severity: 'error',
                   trace: []
                 };
                 messages.push(msg);
                 sub = null;
-              } else {
+              } else if (sub !== null) {
                 // Just a description in the current block. Only add it when in submessage
                 // because Linter does the job for high-level messages.
-                if (sub !== null) {
-                  sub.message += '\n' + line;
-                }
+                sub.message += '\n' + line;
               }
             }
           }


### PR DESCRIPTION
I've improved parsing of output:
1. Errors and Warnings are now fully matched with those of rustc.
2. Notes and Helps are added to the corresponding Errors and Warnings as Info blocks of `trace`. They can also exist as standalone messages.
3. Additional lines with useful information are parsed and added to the appropriet message blocks.
4. Panics are parsed along with their Stack backtraces (which are added as elements of their `trace`).
5. There's only one entry point for output parsing and it fully supports both standard human-readable output as well as JSON format.

So, all the compiler and program messages are now neatly arranged, no information is lost in both standard and JSON modes. Works well with clippy.

Please, check, if everything is ok. Any feedback on the code, usability and anything else is highly appreciated.
