### PR TITLE
Fix unfollowable paths in output messages

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -102,13 +102,15 @@ export function provideBuilder() {
         return level.charAt(0).toUpperCase() + level.slice(1);
       }
 
-      // Checks if a file pointed by a message relates to the Rust source code and
-      // corrects it if needed and if possible
+      // Checks if a file pointed by a message relates to the Rust source code
+      // (has one of the predefined prefixes) and corrects it if needed and if possible
       function normalizePath(path) {
         if (rustSrcPath) {
           const prefix = path.substring(0, rustSrcPrefixLen);
           if (prefix === unixRustSrcPrefix || prefix === windowsRustSrcPrefix) {
-            return rustSrcPath + path.substring(rustSrcPrefixLen - 1); // detract 1 to preserve the original delimiter
+            // Combine RUST_SRC_PATH with what follows after the prefix
+            // Subtract 1 to preserve the original delimiter
+            return rustSrcPath + path.substring(rustSrcPrefixLen - 1);
           }
         }
         return path;

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -68,6 +68,7 @@ export function provideBuilder() {
 
     settings() {
       const cargoPath = atom.config.get('build-cargo.cargoPath');
+      const rustSrcPath = process.env['RUST_SRC_PATH'];
       const args = [];
       atom.config.get('build-cargo.verbose') && args.push('--verbose');
 
@@ -94,6 +95,18 @@ export function provideBuilder() {
 
       function level2type(level) {
         return level.charAt(0).toUpperCase() + level.slice(1);
+      }
+
+      // Checks if a file pointed by a message relates to the Rust source code and
+      // corrects it if needed and if possible
+      function normalizePath(path) {
+        if (rustSrcPath && path.length > 7) {
+          let prefix = path.substring(0, 7);
+          if (prefix === '../src/' || prefix === '..\\src\\') {
+            return rustSrcPath + path.substring(6);
+          }
+        }
+        return path;
       }
 
       // Parses json output
@@ -167,7 +180,7 @@ export function provideBuilder() {
               if (level === 'error' || level === 'warning' || msg === null) {
                 msg = {
                   message: message,
-                  file: match[1],
+                  file: normalizePath(match[1]),
                   line: match[2],
                   line_end: match[4],
                   col: match[3],
@@ -181,7 +194,7 @@ export function provideBuilder() {
               } else {
                 sub = {
                   message: message,
-                  file: match[1],
+                  file: normalizePath(match[1]),
                   line: match[2],
                   line_end: match[4],
                   col: match[3],
@@ -193,11 +206,11 @@ export function provideBuilder() {
               }
             } else {
               // Check for panic
-              match = /(thread '[^']+' panicked at '[^']+'), ([^\/][^\:]+):(\d+)/g.exec(line);
+              match = /(thread '.+' panicked at '.+'), ([^\/][^\:]+):(\d+)/g.exec(line);
               if (match) {
                 msg = {
                   message: match[1],
-                  file: match[2],
+                  file: normalizePath(match[2]),
                   line: match[3],
                   type: 'Panic',
                   severity: 'error',

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -68,9 +68,14 @@ export function provideBuilder() {
 
     settings() {
       const cargoPath = atom.config.get('build-cargo.cargoPath');
-      const rustSrcPath = process.env.RUST_SRC_PATH;
       const args = [];
       atom.config.get('build-cargo.verbose') && args.push('--verbose');
+
+      // Constants to detect links to Rust's source code and make them followable
+      const unixRustSrcPrefix = '../src/';
+      const windowsRustSrcPrefix = '..\\src\\';
+      const rustSrcPrefixLen = unixRustSrcPrefix.length;  // Equal for both unix and windows
+      const rustSrcPath = process.env.RUST_SRC_PATH;
 
       const docArgs = [ 'doc' ];
       atom.config.get('build-cargo.openDocs') && docArgs.push('--open');
@@ -100,10 +105,10 @@ export function provideBuilder() {
       // Checks if a file pointed by a message relates to the Rust source code and
       // corrects it if needed and if possible
       function normalizePath(path) {
-        if (rustSrcPath && path.length > 6) {
-          const prefix = path.substring(0, 7);
-          if (prefix === '../src/' || prefix === '..\\src\\') {
-            return rustSrcPath + path.substring(6);
+        if (rustSrcPath) {
+          const prefix = path.substring(0, rustSrcPrefixLen);
+          if (prefix === unixRustSrcPrefix || prefix === windowsRustSrcPrefix) {
+            return rustSrcPath + path.substring(rustSrcPrefixLen - 1); // detract 1 to preserve the original delimiter
           }
         }
         return path;

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -68,7 +68,7 @@ export function provideBuilder() {
 
     settings() {
       const cargoPath = atom.config.get('build-cargo.cargoPath');
-      const rustSrcPath = process.env['RUST_SRC_PATH'];
+      const rustSrcPath = process.env.RUST_SRC_PATH;
       const args = [];
       atom.config.get('build-cargo.verbose') && args.push('--verbose');
 
@@ -100,8 +100,8 @@ export function provideBuilder() {
       // Checks if a file pointed by a message relates to the Rust source code and
       // corrects it if needed and if possible
       function normalizePath(path) {
-        if (rustSrcPath && path.length > 7) {
-          let prefix = path.substring(0, 7);
+        if (rustSrcPath && path.length > 6) {
+          const prefix = path.substring(0, 7);
           if (prefix === '../src/' || prefix === '..\\src\\') {
             return rustSrcPath + path.substring(6);
           }


### PR DESCRIPTION
When a program panics the file link in the output message might point to the Rust core or a standard library. That happens, for instance, when the panic is caused by `unwrap()` or similar functions. In this case Linter ends up with a broken link. The PR fixes this problem in cases when the user has the `RUST_SRC_PATH` environment variable set.

The PR fixes #41 where additional details can be found.

It also fixes a problem that led to ignoring panics which description or thread name contained a single quote.
