### PR TITLE
Custom linter messages for Notes, Helps and Panics

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -93,16 +93,7 @@ export function provideBuilder() {
       }
 
       function level2type(level) {
-        // FIXME: Should be changed to the following code when Linter starts respect
-        // severity while setting the message lable color (see https://github.com/steelbrain/linter/issues/1149):
-        // return level.charAt(0).toUpperCase() + level.slice(1);
-        switch (level) {
-          case 'warning': return 'Warning';
-          case 'error': return 'Error';
-          case 'note': return 'Info';
-          case 'help': return 'Info';
-          default: return 'Error';
-        }
+        return level.charAt(0).toUpperCase() + level.slice(1);
       }
 
       // Parses json output
@@ -208,7 +199,7 @@ export function provideBuilder() {
                   message: match[1],
                   file: match[2],
                   line: match[3],
-                  type: 'Error',
+                  type: 'Panic',
                   severity: 'error',
                   trace: []
                 };

--- a/styles/linter.less
+++ b/styles/linter.less
@@ -1,0 +1,41 @@
+@import "ui-variables";
+
+// Customizing Linter Message Types
+atom-text-editor::shadow .linter-highlight, .linter-highlight{
+  &.note {
+    &:not(.line-number){
+      background-color: @background-color-info;
+      color: white;
+    }
+    .linter-gutter{
+      color: @background-color-info;
+    }
+    .region {
+      border-bottom: 1px dashed @background-color-info;
+    }
+  }
+  &.help {
+    &:not(.line-number){
+      background-color: @background-color-info;
+      color: white;
+    }
+    .linter-gutter{
+      color: @background-color-info;
+    }
+    .region {
+      border-bottom: 1px dashed @background-color-info;
+    }
+  }
+  &.panic {
+    &:not(.line-number){
+      background-color: @background-color-error;
+      color: white;
+    }
+    .linter-gutter{
+      color: @background-color-error;
+    }
+    .region {
+      border-bottom: 1px dashed @background-color-error;
+    }
+  }
+}


### PR DESCRIPTION
I've added custom Linter message types for Notes, Helps and Panics as described in [the Linter wiki](https://github.com/steelbrain/linter/wiki/Registering-Custom-Message-Types). Thus, there's no need to cram Rust's message levels and panics into the standard Linter message types. They are now displayed with their original names and with appropriate colors.
