### PR TITLE
Multi-crate projects support

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -250,24 +250,24 @@ export function provideBuilder() {
       // Returns the closest directory with Cargo.toml in it.
       // If there's no such directory, returns undefined.
       function findCargoProjectDir(p) {
-          const parts = path.parse(p);
-          const cargoToml = path.format({
-              dir: parts.dir,
-              base: 'Cargo.toml'
-          });
-          try {
-              if (fs.statSync(cargoToml).isFile()) {
-                  return parts.dir;
-              }
-          } catch(e) {
-            if (e.code !== 'ENOENT') {  // No such file (Cargo.toml)
-              throw e;
+        const parts = path.parse(p);
+        const cargoToml = path.format({
+            dir: parts.dir,
+            base: 'Cargo.toml'
+        });
+        try {
+            if (fs.statSync(cargoToml).isFile()) {
+                return parts.dir;
             }
+        } catch (e) {
+          if (e.code !== 'ENOENT') {  // No such file (Cargo.toml)
+            throw e;
           }
-          if (isRoot(parts)) {
-            return undefined;
-          }
-          return findCargoProjectDir(parts.dir);
+        }
+        if (isRoot(parts)) {
+          return undefined;
+        }
+        return findCargoProjectDir(parts.dir);
       }
 
       // This function is called before every build. It finds the closest

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import fs from 'fs';
+import path from 'path';
 
 export const config = {
   cargoPath: {
@@ -236,6 +237,51 @@ export function provideBuilder() {
         return messages;
       }
 
+      // Checks if the given object represents the root of the project or file system
+      function isRoot(parts) {
+        if (parts.dir === parts.root) {
+          return true;    // The file system root
+        }
+        return atom.project.getDirectories().some(dir => {
+          return parts.dir === path.normalize(dir.path);
+        });
+      }
+
+      // Returns the closest directory with Cargo.toml in it.
+      // If there's no such directory, returns undefined.
+      function findCargoProjectDir(p) {
+          const parts = path.parse(p);
+          const cargoToml = path.format({
+              dir: parts.dir,
+              base: 'Cargo.toml'
+          });
+          try {
+              if (fs.statSync(cargoToml).isFile()) {
+                  return parts.dir;
+              }
+          } catch(e) {
+            if (e.code !== 'ENOENT') {  // No such file (Cargo.toml)
+              throw e;
+            }
+          }
+          if (isRoot(parts)) {
+            return undefined;
+          }
+          return findCargoProjectDir(parts.dir);
+      }
+
+      // This function is called before every build. It finds the closest
+      // Cargo.toml file in the path and uses its directory as working.
+      function preBuild() {
+        const editor = atom.workspace.getActivePaneItem();
+        if (editor && editor.buffer && editor.buffer.file) {
+          const wd = findCargoProjectDir(editor.buffer.file.path);
+          if (wd) {
+            this.cwd = wd;
+          }
+        }
+      }
+
       const commands = [
         {
           name: 'Cargo: build (debug)',
@@ -244,7 +290,8 @@ export function provideBuilder() {
           args: [ 'build' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:build-debug'
+          atomCommandName: 'cargo:build-debug',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: build (release)',
@@ -253,7 +300,8 @@ export function provideBuilder() {
           args: [ 'build', '--release' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:build-release'
+          atomCommandName: 'cargo:build-release',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: bench',
@@ -262,7 +310,8 @@ export function provideBuilder() {
           args: [ 'bench' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:bench'
+          atomCommandName: 'cargo:bench',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: clean',
@@ -271,7 +320,8 @@ export function provideBuilder() {
           args: [ 'clean' ].concat(args),
           sh: false,
           errorMatch: [],
-          atomCommandName: 'cargo:clean'
+          atomCommandName: 'cargo:clean',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: doc',
@@ -280,7 +330,8 @@ export function provideBuilder() {
           args: docArgs.concat(args),
           sh: false,
           errorMatch: [],
-          atomCommandName: 'cargo:doc'
+          atomCommandName: 'cargo:doc',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: run (debug)',
@@ -289,7 +340,8 @@ export function provideBuilder() {
           args: [ 'run' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:run-debug'
+          atomCommandName: 'cargo:run-debug',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: run (release)',
@@ -298,7 +350,8 @@ export function provideBuilder() {
           args: [ 'run', '--release' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:run-release'
+          atomCommandName: 'cargo:run-release',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: test',
@@ -307,7 +360,8 @@ export function provideBuilder() {
           args: [ 'test' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:run-test'
+          atomCommandName: 'cargo:run-test',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: update',
@@ -316,7 +370,8 @@ export function provideBuilder() {
           args: [ 'update' ].concat(args),
           sh: false,
           errorMatch: [],
-          atomCommandName: 'cargo:update'
+          atomCommandName: 'cargo:update',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: build example',
@@ -325,7 +380,8 @@ export function provideBuilder() {
           args: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:build-example'
+          atomCommandName: 'cargo:build-example',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: run example',
@@ -334,7 +390,8 @@ export function provideBuilder() {
           args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:run-example'
+          atomCommandName: 'cargo:run-example',
+          preBuild: preBuild
         },
         {
           name: 'Cargo: run bin',
@@ -343,7 +400,8 @@ export function provideBuilder() {
           args: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:run-bin'
+          atomCommandName: 'cargo:run-bin',
+          preBuild: preBuild
         }
       ];
 
@@ -355,7 +413,8 @@ export function provideBuilder() {
           args: ['clippy'].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:clippy'
+          atomCommandName: 'cargo:clippy',
+          preBuild: preBuild
         });
       }
 
@@ -367,7 +426,8 @@ export function provideBuilder() {
           args: ['check'].concat(args),
           sh: false,
           functionMatch: matchFunction,
-          atomCommandName: 'cargo:check'
+          atomCommandName: 'cargo:check',
+          preBuild: preBuild
         });
       }
 

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -10,46 +10,53 @@ export const config = {
     default: 'cargo',
     order: 1
   },
+  multiCrateProjects: {
+    title: 'Enable multi-crate projects support',
+    description: 'Build internal crates separately based on the current open file',
+    type: 'boolean',
+    default: false,
+    order: 2
+  },
   verbose: {
     title: 'Verbose Cargo output',
     description: 'Pass the --verbose flag to cargo',
     type: 'boolean',
     default: false,
-    order: 2
+    order: 3
   },
   openDocs: {
     title: 'Open documentation in browser after \'doc\' target is built',
     type: 'boolean',
     default: false,
-    order: 3
+    order: 4
   },
   showBacktrace: {
     title: 'Show backtrace information in tests',
     description: 'Set environment variable RUST_BACKTRACE=1',
     type: 'boolean',
     default: false,
-    order: 4
+    order: 5
   },
   cargoCheck: {
     title: 'Enable `cargo check',
     description: 'Enable the `cargo check` Cargo command. Only use this if you have `cargo check` installed.',
     type: 'boolean',
     default: false,
-    order: 5
+    order: 6
   },
   cargoClippy: {
     title: 'Enable `cargo clippy',
     description: 'Enable the `cargo clippy` Cargo command to run Clippy\'s lints. Only use this if you have the `cargo clippy` package installed.',
     type: 'boolean',
     default: false,
-    order: 6
+    order: 7
   },
   jsonErrors: {
     title: 'Use json errors',
     description: 'Instead of using regex to parse the human readable output (requires rustc version 1.7)\nNote: this is an unstable feature of the Rust compiler and prone to change and break frequently.',
     type: 'boolean',
     default: false,
-    order: 7
+    order: 8
   }
 };
 
@@ -69,6 +76,7 @@ export function provideBuilder() {
 
     settings() {
       const cargoPath = atom.config.get('build-cargo.cargoPath');
+      const multiCrateProjects = atom.config.get('build-cargo.multiCrateProjects');
       const args = [];
       atom.config.get('build-cargo.verbose') && args.push('--verbose');
 
@@ -276,7 +284,7 @@ export function provideBuilder() {
 
       // This function is called before every build. It finds the closest
       // Cargo.toml file in the path and uses its directory as working.
-      function preBuild() {
+      preBuildFunction = multiCrateProjects && function() {
         const editor = atom.workspace.getActivePaneItem();
         if (editor && editor.buffer && editor.buffer.file) {
           const wdInfo = findCargoProjectDir(editor.buffer.file.path);
@@ -297,7 +305,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-debug',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: build (release)',
@@ -307,7 +315,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-release',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: bench',
@@ -317,7 +325,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:bench',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: clean',
@@ -327,7 +335,7 @@ export function provideBuilder() {
           sh: false,
           errorMatch: [],
           atomCommandName: 'cargo:clean',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: doc',
@@ -337,7 +345,7 @@ export function provideBuilder() {
           sh: false,
           errorMatch: [],
           atomCommandName: 'cargo:doc',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: run (debug)',
@@ -347,7 +355,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-debug',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: run (release)',
@@ -357,7 +365,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-release',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: test',
@@ -367,7 +375,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-test',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: update',
@@ -377,7 +385,7 @@ export function provideBuilder() {
           sh: false,
           errorMatch: [],
           atomCommandName: 'cargo:update',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: build example',
@@ -387,7 +395,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:build-example',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: run example',
@@ -397,7 +405,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-example',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         },
         {
           name: 'Cargo: run bin',
@@ -407,7 +415,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:run-bin',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         }
       ];
 
@@ -420,7 +428,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:clippy',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         });
       }
 
@@ -433,7 +441,7 @@ export function provideBuilder() {
           sh: false,
           functionMatch: matchFunction,
           atomCommandName: 'cargo:check',
-          preBuild: preBuild
+          preBuild: preBuildFunction
         });
       }
 

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -74,6 +74,7 @@ export function provideBuilder() {
     }
 
     settings() {
+      const path = require('path');
       const cargoPath = atom.config.get('build-cargo.cargoPath');
       const multiCrateProjects = atom.config.get('build-cargo.multiCrateProjects');
       const args = [];

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -113,16 +113,16 @@ export function provideBuilder() {
 
       // Checks if a file pointed by a message relates to the Rust source code
       // (has one of the predefined prefixes) and corrects it if needed and if possible
-      function normalizePath(path) {
+      function normalizePath(filePath) {
         if (rustSrcPath) {
-          const prefix = path.substring(0, rustSrcPrefixLen);
+          const prefix = filePath.substring(0, rustSrcPrefixLen);
           if (prefix === unixRustSrcPrefix || prefix === windowsRustSrcPrefix) {
             // Combine RUST_SRC_PATH with what follows after the prefix
             // Subtract 1 to preserve the original delimiter
-            return rustSrcPath + path.substring(rustSrcPrefixLen - 1);
+            return rustSrcPath + filePath.substring(rustSrcPrefixLen - 1);
           }
         }
-        return path;
+        return filePath;
       }
 
       // Parses json output

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -1,7 +1,6 @@
 'use babel';
 
 import fs from 'fs';
-import path from 'path';
 
 export const config = {
   cargoPath: {
@@ -284,7 +283,7 @@ export function provideBuilder() {
 
       // This function is called before every build. It finds the closest
       // Cargo.toml file in the path and uses its directory as working.
-      preBuildFunction = multiCrateProjects && function() {
+      const preBuildFunction = multiCrateProjects && function () {
         const editor = atom.workspace.getActivePaneItem();
         if (editor && editor.buffer && editor.buffer.file) {
           const wdInfo = findCargoProjectDir(editor.buffer.file.path);
@@ -294,7 +293,7 @@ export function provideBuilder() {
             this.cwd = wdInfo.dir;
           }
         }
-      }
+      };
 
       const commands = [
         {

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -251,20 +251,24 @@ export function provideBuilder() {
       // If there's no such directory, returns undefined.
       function findCargoProjectDir(p) {
         const parts = path.parse(p);
+        const root = isRoot(parts);
         const cargoToml = path.format({
-            dir: parts.dir,
-            base: 'Cargo.toml'
+          dir: parts.dir,
+          base: 'Cargo.toml'
         });
         try {
-            if (fs.statSync(cargoToml).isFile()) {
-                return parts.dir;
-            }
+          if (fs.statSync(cargoToml).isFile()) {
+            return {
+              dir: parts.dir,
+              root: root
+            };
+          }
         } catch (e) {
           if (e.code !== 'ENOENT') {  // No such file (Cargo.toml)
             throw e;
           }
         }
-        if (isRoot(parts)) {
+        if (root) {
           return undefined;
         }
         return findCargoProjectDir(parts.dir);
@@ -275,9 +279,11 @@ export function provideBuilder() {
       function preBuild() {
         const editor = atom.workspace.getActivePaneItem();
         if (editor && editor.buffer && editor.buffer.file) {
-          const wd = findCargoProjectDir(editor.buffer.file.path);
-          if (wd) {
-            this.cwd = wd;
+          const wdInfo = findCargoProjectDir(editor.buffer.file.path);
+          if (wdInfo && !wdInfo.root) {
+            const p = path.parse(wdInfo.dir);
+            atom.notifications.addInfo('Building ' + p.base + '...');
+            this.cwd = wdInfo.dir;
           }
         }
       }


### PR DESCRIPTION
The commit adds support for multi-crate projects, including [cargo workspaces](https://github.com/rust-lang/rfcs/blob/master/text/1525-cargo-workspace.md).

According to the `atom-build`'s rules of activating build providers, `Cargo.toml` must be present in the project root. It might be empty or contain the `[workspace]` block as defined in the RFC linked above (such blocks only work in nightly [1.12] now).

So, a multi-crate project with a "virtual" `Cargo.toml` has the following structure:

```
Cargo.toml
foo/
    src/
    Cargo.toml
bar/
    src/
    Cargo.toml
```

A project with the main crate and its dependencies looks like this:

```
Cargo.toml
src/
dep_a/
    src/
    Cargo.toml
dep_b/
    src/
    Cargo.toml
```

Before executing a build, `atom-build-cargo` looks for the directory with `Cargo.toml` which is the closest parent to the current active file and uses this directory as current for the `cargo` command.

If there's no active file, the command will be executed in the project's root directory. For now, in most cases it will lead to an error, because the RFC is not fully implemented yet. The error is following:

For stable [1.10] and beta [1.11]:

```
error: failed to parse manifest at '/SomePath/MyWorkspace/Cargo.toml'

Caused by:
  no 'package' or 'project' section found.
```

For nightly [1.12]:

```
error: manifest path '/SomePath/MyWorkspace/Cargo.toml' is a virtual manifest, but this command requires running against an actual package in this workspace
```

I think we should not restrain users from running builds in the root directory despite this error because step by step the RFC will be implemented and the error will disappear. Moreover, such restriction cannot be applied to single-crate projects and sometimes it's not obvious if the project is multi-crate or not.

What I would also like to do is to notify the user about the exact crate for which we are running the build now. He or she can find it in the first line of the cargo output, but it would be handy to show some notification if we are working in a multi-crate environment. But the problem here is the same as I described above: It's not obvious if we are running in such environment. I think it could be implemented later, after some additional research.

fixes #44 
