### PR TITLE
Fixed regex for panics

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -193,7 +193,7 @@ export function provideBuilder() {
               }
             } else {
               // Check for panic
-              match = /^(thread '[^']+' panicked at '[^']+'), ([^\/][^\:]+):(\d+)/g.exec(line);
+              match = /(thread '[^']+' panicked at '[^']+'), ([^\/][^\:]+):(\d+)/g.exec(line);
               if (match) {
                 msg = {
                   message: match[1],


### PR DESCRIPTION
When running tests, panic messages are indented. This commit makes the regex aware of this fact.
