### PR TITLE
Fix building multi-crate workspaces in multi-project environment

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -250,8 +250,8 @@ export function provideBuilder() {
         if (parts.dir === parts.root) {
           return true;    // The file system root
         }
-        return atom.project.getDirectories().some(dir => {
-          return parts.dir === path.normalize(dir.path);
+        return atom.project.getPaths().some(p => {
+          return parts.dir === p;
         });
       }
 
@@ -285,14 +285,21 @@ export function provideBuilder() {
       // This function is called before every build. It finds the closest
       // Cargo.toml file in the path and uses its directory as working.
       const preBuildFunction = multiCrateProjects && function () {
-        const editor = atom.workspace.getActivePaneItem();
-        if (editor && editor.buffer && editor.buffer.file) {
-          const wdInfo = findCargoProjectDir(editor.buffer.file.path);
-          if (wdInfo && !wdInfo.root) {
-            const p = path.parse(wdInfo.dir);
-            atom.notifications.addInfo('Building ' + p.base + '...');
+        const editor = atom.workspace.getActiveTextEditor();
+        this.cwd = undefined;
+        if (editor && editor.getPath()) {
+          const wdInfo = findCargoProjectDir(editor.getPath());
+          if (wdInfo) {
+            if (!wdInfo.root) {
+              const p = path.parse(wdInfo.dir);
+              atom.notifications.addInfo('Building ' + p.base + '...');
+            }
             this.cwd = wdInfo.dir;
           }
+        }
+        if (!this.cwd && atom.project.getPaths().length > 0) {
+          // Build in the root of the first path by default
+          this.cwd = atom.project.getPaths()[0];
         }
       };
 


### PR DESCRIPTION
If we have more than one project folders in Atom and some of them contain multi-crate cargo workspaces, switching between them sometimes led to setting wrong directory for the current build. This commit fixes the problem.
