### PR TITLE
Apply setting on the fly

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -22,27 +22,27 @@ export const config = {
   },
   multiCrateProjects: {
     title: 'Enable multi-crate projects support',
-    description: 'Build internal crates separately based on the current open file',
+    description: 'Build internal crates separately based on the current open file.',
     type: 'boolean',
     default: false,
     order: 2
   },
   verbose: {
     title: 'Verbose Cargo output',
-    description: 'Pass the --verbose flag to cargo',
+    description: 'Pass the --verbose flag to Cargo.',
     type: 'boolean',
     default: false,
     order: 3
   },
   showBacktrace: {
-    title: 'Show backtrace information in tests',
-    description: 'Set environment variable RUST_BACKTRACE=1',
+    title: 'Show backtrace information',
+    description: 'Set environment variable RUST_BACKTRACE=1.',
     type: 'boolean',
     default: false,
     order: 4
   },
   jsonErrors: {
-    title: 'Use json errors',
+    title: 'Use json errors format',
     description: 'Instead of using regex to parse the human readable output (requires rustc version 1.7)\nNote: this is an unstable feature of the Rust compiler and prone to change and break frequently.',
     type: 'boolean',
     default: false,

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -2,11 +2,24 @@
 
 import fs from 'fs';
 
+// Transfer existing settings from previous versions of the package
+if (atom.config.get('build-cargo.cargoCheck')) {
+  atom.config.set('build-cargo.extCommands.cargoCheck', true)
+}
+if (atom.config.get('build-cargo.cargoClippy')) {
+  atom.config.set('build-cargo.extCommands.cargoClippy', true)
+}
+// Remove old settings
+atom.config.unset('build-cargo.cargoCheck');
+atom.config.unset('build-cargo.cargoClippy');
+
+const defaultCargoCmd = 'cargo';
+
 export const config = {
   cargoPath: {
     title: 'Path to the Cargo executable',
     type: 'string',
-    default: 'cargo',
+    default: defaultCargoCmd,
     order: 1
   },
   multiCrateProjects: {
@@ -23,39 +36,46 @@ export const config = {
     default: false,
     order: 3
   },
-  openDocs: {
-    title: 'Open documentation in browser after \'doc\' target is built',
-    type: 'boolean',
-    default: false,
-    order: 4
-  },
   showBacktrace: {
     title: 'Show backtrace information in tests',
     description: 'Set environment variable RUST_BACKTRACE=1',
     type: 'boolean',
     default: false,
-    order: 5
-  },
-  cargoCheck: {
-    title: 'Enable `cargo check',
-    description: 'Enable the `cargo check` Cargo command. Only use this if you have `cargo check` installed.',
-    type: 'boolean',
-    default: false,
-    order: 6
-  },
-  cargoClippy: {
-    title: 'Enable `cargo clippy',
-    description: 'Enable the `cargo clippy` Cargo command to run Clippy\'s lints. Only use this if you have the `cargo clippy` package installed.',
-    type: 'boolean',
-    default: false,
-    order: 7
+    order: 4
   },
   jsonErrors: {
     title: 'Use json errors',
     description: 'Instead of using regex to parse the human readable output (requires rustc version 1.7)\nNote: this is an unstable feature of the Rust compiler and prone to change and break frequently.',
     type: 'boolean',
     default: false,
-    order: 8
+    order: 5
+  },
+  openDocs: {
+    title: 'Open documentation in browser after \'doc\' target is built',
+    type: 'boolean',
+    default: false,
+    order: 6
+  },
+  extCommands: {
+    title: 'Extended Commands',
+    type: 'object',
+    order: 7,
+    properties: {
+      cargoCheck: {
+        title: 'Enable cargo check',
+        description: 'Enable the `cargo check` Cargo command. Only use this if you have `cargo check` installed.',
+        type: 'boolean',
+        default: false,
+        order: 1
+      },
+      cargoClippy: {
+        title: 'Enable cargo clippy',
+        description: 'Enable the `cargo clippy` Cargo command to run Clippy\'s lints. Only use this if you have the `cargo clippy` package installed.',
+        type: 'boolean',
+        default: false,
+        order: 2
+      }
+    }
   }
 };
 
@@ -75,27 +95,12 @@ export function provideBuilder() {
 
     settings() {
       const path = require('path');
-      const cargoPath = atom.config.get('build-cargo.cargoPath');
-      const multiCrateProjects = atom.config.get('build-cargo.multiCrateProjects');
-      const args = [];
-      atom.config.get('build-cargo.verbose') && args.push('--verbose');
 
       // Constants to detect links to Rust's source code and make them followable
       const unixRustSrcPrefix = '../src/';
       const windowsRustSrcPrefix = '..\\src\\';
       const rustSrcPrefixLen = unixRustSrcPrefix.length;  // Equal for both unix and windows
       const rustSrcPath = process.env.RUST_SRC_PATH;
-
-      const docArgs = [ 'doc' ];
-      atom.config.get('build-cargo.openDocs') && docArgs.push('--open');
-
-      const env = {};
-      if (atom.config.get('build-cargo.jsonErrors')) {
-        env.RUSTFLAGS = '-Z unstable-options --error-format=json';
-      }
-      if (atom.config.get('build-cargo.showBacktrace')) {
-        env.RUST_BACKTRACE = '1';
-      }
 
       let buildWorkDir;        // The last build workding directory (might differ from the project root for multi-crate projects)
       let panicsCounter = 0;   // Counts all panics
@@ -372,10 +377,23 @@ export function provideBuilder() {
 
       // This function is called before every build. It finds the closest
       // Cargo.toml file in the path and uses its directory as working.
-      const preBuildFunction = function () {
-        if (multiCrateProjects) {
+      function prepareBuild(buildCfg) {
+        // Common build command parameters
+        buildCfg.exec = atom.config.get('build-cargo.cargoPath');
+        buildCfg.env = {};
+        if (atom.config.get('build-cargo.jsonErrors')) {
+          buildCfg.env.RUSTFLAGS = '-Z unstable-options --error-format=json';
+        }
+        if (atom.config.get('build-cargo.showBacktrace')) {
+          buildCfg.env.RUST_BACKTRACE = '1';
+        }
+        buildCfg.args = buildCfg.args || [];
+        atom.config.get('build-cargo.verbose') && buildCfg.args.push('--verbose');
+
+        // Substitute working directory if we are in a multi-crate environment
+        if (atom.config.get('build-cargo.multiCrateProjects')) {
           const editor = atom.workspace.getActiveTextEditor();
-          this.cwd = undefined;
+          buildCfg.cwd = undefined;
           if (editor && editor.getPath()) {
             const wdInfo = findCargoProjectDir(editor.getPath());
             if (wdInfo) {
@@ -383,165 +401,111 @@ export function provideBuilder() {
                 const p = path.parse(wdInfo.dir);
                 atom.notifications.addInfo('Building ' + p.base + '...');
               }
-              this.cwd = wdInfo.dir;
+              buildCfg.cwd = wdInfo.dir;
             }
           }
         }
-        if (!this.cwd && atom.project.getPaths().length > 0) {
+        if (!buildCfg.cwd && atom.project.getPaths().length > 0) {
           // Build in the root of the first path by default
-          this.cwd = atom.project.getPaths()[0];
+          buildCfg.cwd = atom.project.getPaths()[0];
         }
-        buildWorkDir = this.cwd;
-      };
+        buildWorkDir = buildCfg.cwd;
+      }
 
       const commands = [
         {
           name: 'Cargo: build (debug)',
-          exec: cargoPath,
-          env: env,
-          args: [ 'build' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:build-debug',
-          preBuild: preBuildFunction
+          argsCfg: [ 'build' ]
         },
         {
           name: 'Cargo: build (release)',
-          exec: cargoPath,
-          env: env,
-          args: [ 'build', '--release' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:build-release',
-          preBuild: preBuildFunction
+          argsCfg: [ 'build', '--release' ]
         },
         {
           name: 'Cargo: bench',
-          exec: cargoPath,
-          env: env,
-          args: [ 'bench' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:bench',
-          preBuild: preBuildFunction
+          argsCfg: [ 'bench' ]
         },
         {
           name: 'Cargo: clean',
-          exec: cargoPath,
-          env: env,
-          args: [ 'clean' ].concat(args),
-          sh: false,
-          errorMatch: [],
           atomCommandName: 'cargo:clean',
-          preBuild: preBuildFunction
+          argsCfg: [ 'clean' ]
         },
         {
           name: 'Cargo: doc',
-          exec: cargoPath,
-          env: env,
-          args: docArgs.concat(args),
-          sh: false,
-          errorMatch: [],
           atomCommandName: 'cargo:doc',
-          preBuild: preBuildFunction
+          argsCfg: [ 'doc' ],
+          preConfig: function() {
+            atom.config.get('build-cargo.openDocs') && this.args.push('--open');
+          }
         },
         {
           name: 'Cargo: run (debug)',
-          exec: cargoPath,
-          env: env,
-          args: [ 'run' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:run-debug',
-          preBuild: preBuildFunction
+          argsCfg: [ 'run' ]
         },
         {
           name: 'Cargo: run (release)',
-          exec: cargoPath,
-          env: env,
-          args: [ 'run', '--release' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:run-release',
-          preBuild: preBuildFunction
+          argsCfg: [ 'run', '--release' ]
         },
         {
           name: 'Cargo: test',
-          exec: cargoPath,
-          env: env,
-          args: [ 'test' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:run-test',
-          preBuild: preBuildFunction
+          argsCfg: [ 'test' ]
         },
         {
           name: 'Cargo: update',
-          exec: cargoPath,
-          env: env,
-          args: [ 'update' ].concat(args),
-          sh: false,
-          errorMatch: [],
           atomCommandName: 'cargo:update',
-          preBuild: preBuildFunction
+          argsCfg: [ 'update' ]
         },
         {
           name: 'Cargo: build example',
-          exec: cargoPath,
-          env: env,
-          args: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:build-example',
-          preBuild: preBuildFunction
+          argsCfg: [ 'build', '--example', '{FILE_ACTIVE_NAME_BASE}' ]
         },
         {
           name: 'Cargo: run example',
-          exec: cargoPath,
-          env: env,
-          args: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:run-example',
-          preBuild: preBuildFunction
+          argsCfg: [ 'run', '--example', '{FILE_ACTIVE_NAME_BASE}' ]
         },
         {
           name: 'Cargo: run bin',
-          exec: cargoPath,
-          env: env,
-          args: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:run-bin',
-          preBuild: preBuildFunction
+          argsCfg: [ 'run', '--bin', '{FILE_ACTIVE_NAME_BASE}' ]
         }
       ];
 
-      if (atom.config.get('build-cargo.cargoClippy')) {
+      if (atom.config.get('build-cargo.extCommands.cargoClippy')) {
         commands.push({
           name: 'Cargo: Clippy',
-          exec: cargoPath,
-          env: env,
-          args: ['clippy'].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:clippy',
-          preBuild: preBuildFunction
+          argsCfg: [ 'clippy' ]
         });
       }
 
-      if (atom.config.get('build-cargo.cargoCheck')) {
+      if (atom.config.get('build-cargo.extCommands.cargoCheck')) {
         commands.push({
           name: 'Cargo: check',
-          exec: cargoPath,
-          env: env,
-          args: ['check'].concat(args),
-          sh: false,
-          functionMatch: matchFunction,
           atomCommandName: 'cargo:check',
-          preBuild: preBuildFunction
+          argsCfg: [ 'check' ]
         });
       }
+
+      commands.forEach(cmd => {
+        cmd.exec = defaultCargoCmd;
+        cmd.sh = false;
+        cmd.functionMatch = matchFunction;
+        cmd.preBuild = function() {
+          this.args = this.argsCfg.slice(0);    // Clone initial arguments
+          if (this.preConfig) {
+            this.preConfig();                   // Allow the command to configure its arguments
+          }
+          prepareBuild(this);
+        };
+      });
 
       return commands;
     }

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -4,10 +4,10 @@ import fs from 'fs';
 
 // Transfer existing settings from previous versions of the package
 if (atom.config.get('build-cargo.cargoCheck')) {
-  atom.config.set('build-cargo.extCommands.cargoCheck', true)
+  atom.config.set('build-cargo.extCommands.cargoCheck', true);
 }
 if (atom.config.get('build-cargo.cargoClippy')) {
-  atom.config.set('build-cargo.extCommands.cargoClippy', true)
+  atom.config.set('build-cargo.extCommands.cargoClippy', true);
 }
 // Remove old settings
 atom.config.unset('build-cargo.cargoCheck');
@@ -437,7 +437,7 @@ export function provideBuilder() {
           name: 'Cargo: doc',
           atomCommandName: 'cargo:doc',
           argsCfg: [ 'doc' ],
-          preConfig: function() {
+          preConfig: function () {
             atom.config.get('build-cargo.openDocs') && this.args.push('--open');
           }
         },
@@ -498,7 +498,7 @@ export function provideBuilder() {
         cmd.exec = defaultCargoCmd;
         cmd.sh = false;
         cmd.functionMatch = matchFunction;
-        cmd.preBuild = function() {
+        cmd.preBuild = function () {
           this.args = this.argsCfg.slice(0);    // Clone initial arguments
           if (this.preConfig) {
             this.preConfig();                   // Allow the command to configure its arguments

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -13,13 +13,11 @@ if (atom.config.get('build-cargo.cargoClippy')) {
 atom.config.unset('build-cargo.cargoCheck');
 atom.config.unset('build-cargo.cargoClippy');
 
-const defaultCargoCmd = 'cargo';
-
 export const config = {
   cargoPath: {
     title: 'Path to the Cargo executable',
     type: 'string',
-    default: defaultCargoCmd,
+    default: 'cargo',
     order: 1
   },
   multiCrateProjects: {
@@ -495,7 +493,7 @@ export function provideBuilder() {
       }
 
       commands.forEach(cmd => {
-        cmd.exec = defaultCargoCmd;
+        cmd.exec = atom.config.get('build-cargo.cargoPath');
         cmd.sh = false;
         cmd.functionMatch = matchFunction;
         cmd.preBuild = function () {

--- a/spec/cargo-spec.js
+++ b/spec/cargo-spec.js
@@ -43,13 +43,13 @@ describe('cargo', () => {
           const defaultTarget = settings[0]; // default MUST be first
           expect(defaultTarget.name).toBe('Cargo: build (debug)');
           expect(defaultTarget.exec).toBe('/this/is/just/a/dummy/path/cargo');
-          expect(defaultTarget.args).toEqual([ 'build' ]);
+          expect(defaultTarget.argsCfg).toEqual([ 'build' ]);
           expect(defaultTarget.sh).toBe(false);
 
           const target = settings.find(setting => setting.name === 'Cargo: test');
           expect(target.name).toBe('Cargo: test');
           expect(target.exec).toBe('/this/is/just/a/dummy/path/cargo');
-          expect(target.args).toEqual([ 'test' ]);
+          expect(target.argsCfg).toEqual([ 'test' ]);
           expect(target.sh).toBe(false);
         });
       });


### PR DESCRIPTION
Setting changes are now applied immediately, without reloading.
'Cargo check' and 'Cargo clippy' settings are moved into their own group. They still need reload to take effect.

Fixes #50 and it seems that it fixes #39 too.
