### PR TITLE
Support of a compact backtraces format

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -3,6 +3,9 @@
 import fs from 'fs';
 
 // Transfer existing settings from previous versions of the package
+if (atom.config.get('build-cargo.showBacktrace')) {
+  atom.config.set('build-cargo.backtraceType', 'Compact');
+}
 if (atom.config.get('build-cargo.cargoCheck')) {
   atom.config.set('build-cargo.extCommands.cargoCheck', true);
 }
@@ -10,6 +13,7 @@ if (atom.config.get('build-cargo.cargoClippy')) {
   atom.config.set('build-cargo.extCommands.cargoClippy', true);
 }
 // Remove old settings
+atom.config.unset('build-cargo.showBacktrace');
 atom.config.unset('build-cargo.cargoCheck');
 atom.config.unset('build-cargo.cargoClippy');
 
@@ -34,11 +38,12 @@ export const config = {
     default: false,
     order: 3
   },
-  showBacktrace: {
-    title: 'Show backtrace information',
-    description: 'Set environment variable RUST_BACKTRACE=1.',
-    type: 'boolean',
-    default: false,
+  backtraceType: {
+    title: 'Backtrace',
+    description: 'Stack backtrace verbosity level. Uses the environment variable RUST_BACKTRACE=1 if not `Off`.',
+    type: 'string',
+    default: 'Off',
+    enum: [ 'Off', 'Compact', 'Full' ],
     order: 4
   },
   jsonErrors: {
@@ -208,9 +213,12 @@ export function provideBuilder() {
           const panicLines = [];
           for (let j = i + 1; j < lines.length; j++) {
             line = lines[j];
-            const matchFunc = /^\s+(\d+):\s+(0x[a-f0-9]+) - (.+)$/g.exec(line);
+            const matchFunc = /^(\s+\d+):\s+0x[a-f0-9]+ - (?:(.+)::h[0-9a-f]+|(.+))$/g.exec(line);
             if (matchFunc) {
               // A line with a function call
+              if (atom.config.get('build-cargo.backtraceType') === 'Compact') {
+                line = matchFunc[1] + ':  ' + (matchFunc[2] || matchFunc[3]);
+              }
               panicLines.push(line);
             } else {
               const matchLink = /(at (.+):(\d+))$/g.exec(line);
@@ -382,7 +390,7 @@ export function provideBuilder() {
         if (atom.config.get('build-cargo.jsonErrors')) {
           buildCfg.env.RUSTFLAGS = '-Z unstable-options --error-format=json';
         }
-        if (atom.config.get('build-cargo.showBacktrace')) {
+        if (atom.config.get('build-cargo.backtraceType') !== 'Off') {
           buildCfg.env.RUST_BACKTRACE = '1';
         }
         buildCfg.args = buildCfg.args || [];


### PR DESCRIPTION
I've added support of a compact format for backtraces as described in the issue #54.

For those users who now have 'Show Bakctrace' flag on, the new setting will be automatically set to Compact.
