### PR TITLE
Support for colored output

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -278,7 +278,11 @@ export function provideBuilder() {
         let panicsN = 0;        // quantity of panics in this output
         const lines = output.split(/\n/);
         for (let i = 0; i < lines.length; i++) {
-          const line = lines[i];
+          let line = lines[i];
+          if (!atom.config.get('build-cargo.jsonErrors')) {
+            // Remove ANSI escape codes from output
+            line = line.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+          }
           // Cargo final error messages start with 'error:', skip them
           if (line === null || line === '' || line.substring(0, 6) === 'error:') {
             msg = null;
@@ -389,6 +393,9 @@ export function provideBuilder() {
         buildCfg.env = {};
         if (atom.config.get('build-cargo.jsonErrors')) {
           buildCfg.env.RUSTFLAGS = '-Z unstable-options --error-format=json';
+        } else {
+          buildCfg.env.TERM = 'xterm';
+          buildCfg.env.RUSTFLAGS = '--color=always';
         }
         if (atom.config.get('build-cargo.backtraceType') !== 'Off') {
           buildCfg.env.RUST_BACKTRACE = '1';

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -279,7 +279,7 @@ export function provideBuilder() {
         const lines = output.split(/\n/);
         for (let i = 0; i < lines.length; i++) {
           let line = lines[i];
-          if (!atom.config.get('build-cargo.jsonErrors')) {
+          if (!useJson) {
             // Remove ANSI escape codes from output
             line = line.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
           }

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -393,7 +393,7 @@ export function provideBuilder() {
         buildCfg.env = {};
         if (atom.config.get('build-cargo.jsonErrors')) {
           buildCfg.env.RUSTFLAGS = '-Z unstable-options --error-format=json';
-        } else {
+        } else if (process.platform !== 'win32') {
           buildCfg.env.TERM = 'xterm';
           buildCfg.env.RUSTFLAGS = '--color=always';
         }


### PR DESCRIPTION
I've added support for colored rustc output.

The only way it works now, is by setting the `TERM=xterm` environment variable (the value may differ, but I think `xterm` should work under all circumstances) and `--color=always` option for `rustc`. The output parsing was also fixed to remove ANSI escape symbols that are emitted by the colored output.

Fixes #56 
