### PR TITLE
Fixed the problem with compile errors within macros

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -102,8 +102,6 @@ export function provideBuilder() {
       // Constants to detect links to Rust's source code and make them followable
       const unixRustSrcPrefix = '../src/';
       const windowsRustSrcPrefix = '..\\src\\';
-      const rustSrcPrefixLen = unixRustSrcPrefix.length;  // Equal for both unix and windows
-      const rustSrcPath = process.env.RUST_SRC_PATH;
 
       let buildWorkDir;        // The last build workding directory (might differ from the project root for multi-crate projects)
       let panicsCounter = 0;   // Counts all panics
@@ -125,57 +123,62 @@ export function provideBuilder() {
 
       // Checks if the given file path returned by rustc or cargo points to the Rust source code
       function isRustSourceLink(filePath) {
-        const prefix = filePath.substring(0, rustSrcPrefixLen);
-        return prefix === unixRustSrcPrefix || prefix === windowsRustSrcPrefix;
+        return filePath.startsWith(unixRustSrcPrefix) || filePath.startsWith(windowsRustSrcPrefix);
       }
 
-      // Checks if a file pointed by a message relates to the Rust source code
-      // (has one of the predefined prefixes) and corrects it if needed and if possible
-      function normalizePath(filePath) {
-        if (rustSrcPath && isRustSourceLink(filePath)) {
-          // Combine RUST_SRC_PATH with what follows after the prefix
-          // Subtract 1 to preserve the original delimiter
-          return rustSrcPath + filePath.substring(rustSrcPrefixLen - 1);
+      function parseJsonSpan(span, msg) {
+        if (span && span.file_name && !span.file_name.startsWith('<')) {
+          msg.file = span.file_name;
+          msg.line = span.line_start;
+          msg.line_end = span.line_end;
+          msg.col = span.column_start;
+          msg.col_end = span.column_end;
+          return true;
+        } else if (span.expansion) {
+          return parseJsonSpan(span.expansion.span, msg);
         }
-        return filePath;
+        return false;
       }
 
-      // Parses json output
-      function parseJsonOutput(line, messages) {
-        const json = JSON.parse(line);
-        const trace = [];
-        json.spans.forEach(span => {
-          trace.push({
-            message: span.label,
-            file: span.file_name,
-            line: span.line_start,
-            line_end: span.line_end,
-            col: span.column_start,
-            col_end: span.column_end,
-            type: level2type('note'),
-            severity: level2severity('note')
+      function parseJsonSpans(jsonObj, msg) {
+        if (jsonObj.spans) {
+          jsonObj.spans.forEach(span => {
+            if (parseJsonSpan(span, msg)) {
+              return;
+            }
           });
+        }
+      }
+
+      // Parses a compile message in json format
+      function parseJsonMessage(line, messages) {
+        const json = JSON.parse(line);
+        const msg = {
+          message: json.message,
+          type: level2type(json.level),
+          severity: level2severity(json.level),
+          trace: []
+        };
+        parseJsonSpans(json, msg);
+        json.children.forEach(child => {
+          const tr = {
+            message: child.message,
+            type: level2type(child.level),
+            severity: level2severity(child.level)
+          };
+          parseJsonSpans(child, tr);
+          msg.trace.push(tr);
         });
-        if (json.code) {
-          trace.push({
+        if (json.code && json.code.explanation) {
+          msg.trace.push({
             message: json.code.explanation,
             type: 'Explanation',
             severity: 'info'
           });
         }
-        json.spans.forEach(span => {
-          messages.push({
-            message: json.message,
-            file: span.file_name,
-            line: span.line_start,
-            line_end: span.line_end,
-            col: span.column_start,
-            col_end: span.column_end,
-            type: level2type(json.level),
-            severity: level2severity(json.level),
-            trace: trace
-          });
-        });
+        if (msg.file) { // Root message without `file` is the summary, skip it
+          messages.push(msg);
+        }
       }
 
       // Shows panic info
@@ -289,21 +292,26 @@ export function provideBuilder() {
             sub = null;
           } else if (useJson && line[0] === '{') {
             // Parse a JSON block
-            parseJsonOutput(line, messages);
+            parseJsonMessage(line, messages);
           } else {
             // Check for compilation messages
-            const match = /^(.+.rs):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
+            const match = /^(.+):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
             if (match) {
+              let filePath = match[1];
+              let startLine = match[2];
+              let startCol = match[3];
+              let endLine = match[4];
+              let endCol = match[5];
               const level = match[6];
               const message = match[7];
               if (level === 'error' || level === 'warning' || msg === null) {
                 msg = {
                   message: message,
-                  file: normalizePath(match[1]),
-                  line: match[2],
-                  line_end: match[4],
-                  col: match[3],
-                  col_end: match[5],
+                  file: filePath,
+                  line: startLine,
+                  line_end: endLine,
+                  col: startCol,
+                  col_end: endCol,
                   type: level2type(level),
                   severity: level2severity(level),
                   trace: []
@@ -311,13 +319,28 @@ export function provideBuilder() {
                 messages.push(msg);
                 sub = null;
               } else {
+                if (filePath.startsWith('<')) {
+                  // The message has incorrect file link, omit it
+                  filePath = undefined;
+                  startLine = undefined;
+                  startCol = undefined;
+                  endLine = undefined;
+                  endCol = undefined;
+                } else if (msg.file.startsWith('<')) {
+                  // The root message has incorrect file link, use the one from the extended messsage
+                  msg.file = filePath;
+                  msg.line = startLine;
+                  msg.line_end = endLine;
+                  msg.col = startCol;
+                  msg.col_end = endCol;
+                }
                 sub = {
                   message: message,
-                  file: normalizePath(match[1]),
-                  line: match[2],
-                  line_end: match[4],
-                  col: match[3],
-                  col_end: match[5],
+                  file: filePath,
+                  line: startLine,
+                  line_end: endLine,
+                  col: startCol,
+                  col_end: endCol,
                   type: level2type(level),
                   severity: level2severity(level)
                 };


### PR DESCRIPTION
There're cases when `rustc` doesn't emit correct file names and locations for errors inside macros calls. For instance:

```
<std macros>:5:22: 5:33 error: mismatched types [E0308]
<std macros>:5 if ! ( * left_val == * right_val ) {
                                    ^~~~~~~~~~~
src/lib.rs:37:9: 37:51 note: in this expansion of assert_eq! (defined in <std macros>)
```

For the standard output it's possible to extract the correct file location from one of the additional messages. For the json output it's possible to go recursively through spans and their expansions to find the original location.

The PR uses this technique to find the correct location. In addition, it adapts the json parsing to recent changes in the messages structure. I also removed function `normalizePath()`, it became obsolete after switching panics to notifications.

The json output parsing now works for stable, beta and nightly (1.11, 1.12 and 1.13).

The standard output parsing works for stable and beta. Nightly is switched to the new messages format, so there must be a separate issue to adapt to it.
