### PR TITLE
New error format support

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -133,12 +133,12 @@ export function provideBuilder() {
           }
 
           // Try parse a standard output message
-          if (parsedQty == 0 && !useJson) {
+          if (parsedQty === 0 && !useJson) {
             parsedQty = stdParser.tryParseMessage(lines, i, messages);
           }
 
           // Try parse a panic
-          if (parsedQty == 0) {
+          if (parsedQty === 0) {
             parsedQty = panicParser.tryParsePanic(lines, i, panicsN < panicsLimit, buildWorkDir);
             if (parsedQty > 0) {
               panicsN += 1;

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -49,7 +49,7 @@ export const config = {
   },
   jsonErrorFormat: {
     title: 'Use JSON error format',
-    description: 'Use JSON error format instead of human readable output. When switched off, Linter is not used to display compiler messages.',
+    description: 'Use JSON error format instead of human readable output.',
     type: 'boolean',
     default: true,
     order: 5
@@ -100,101 +100,53 @@ export function provideBuilder() {
     settings() {
       const path = require('path');
       const err = require('./errors');
+      const stdParser = require('./std-parser');
       const jsonParser = require('./json-parser');
       const panicParser = require('./panic-parser');
 
       let buildWorkDir;        // The last build workding directory (might differ from the project root for multi-crate projects)
       const panicsLimit = 10;  // Max number of panics to show at once
 
+      // Split output and remove ANSI escape codes if needed
+      function extractLines(output, removeEscape) {
+        const lines = output.split(/\n/);
+        if (removeEscape) {
+          for (let i = 0; i < lines.length; i++) {
+            lines[i] = lines[i].replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+          }
+        }
+        return lines;
+      }
+
       function matchFunction(output) {
         const useJson = atom.config.get('build-cargo.jsonErrorFormat');
         const messages = [];    // resulting collection of high-level messages
-        let msg = null;         // current high-level message (error, warning or panic)
-        let sub = null;         // current submessage (note or help)
         let panicsN = 0;        // quantity of panics in this output
-        const lines = output.split(/\n/);
+        const lines = extractLines(output, !useJson);
         for (let i = 0; i < lines.length; i++) {
-          let line = lines[i];
-          if (!useJson) {
-            // Remove ANSI escape codes from output
-            line = line.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+          let parsedQty = 0;
+
+          // Try parse a JSON message
+          if (useJson && lines[i].startsWith('{')) {
+            jsonParser.parseMessage(lines[i], messages);
+            parsedQty = 1;
           }
-          // Cargo final error messages start with 'error:', skip them
-          if (line === null || line === '' || line.startsWith('error:')) {
-            msg = null;
-            sub = null;
-          } else if (useJson && line[0] === '{') {
-            // Parse a JSON block
-            jsonParser.parseMessage(line, messages);
-          } else {
-            // Check for compilation messages
-            const match = /^(.+):(\d+):(\d+):(?: (\d+):(\d+))? (error|warning|help|note): (.*)/g.exec(line);
-            if (match) {
-              let filePath = match[1];
-              let startLine = match[2];
-              let startCol = match[3];
-              let endLine = match[4];
-              let endCol = match[5];
-              const level = match[6];
-              const message = match[7];
-              if (level === 'error' || level === 'warning') {
-                msg = {
-                  message: message,
-                  file: filePath,
-                  line: startLine,
-                  line_end: endLine,
-                  col: startCol,
-                  col_end: endCol,
-                  type: err.level2type(level),
-                  severity: err.level2severity(level),
-                  trace: []
-                };
-                messages.push(msg);
-                sub = null;
-              } else {
-                if (filePath.startsWith('<')) {
-                  // The message has incorrect file link, omit it
-                  filePath = undefined;
-                  startLine = undefined;
-                  startCol = undefined;
-                  endLine = undefined;
-                  endCol = undefined;
-                } else if (msg && msg.file.startsWith('<')) {
-                  // The root message has incorrect file link, use the one from the extended messsage
-                  msg.file = filePath;
-                  msg.line = startLine;
-                  msg.line_end = endLine;
-                  msg.col = startCol;
-                  msg.col_end = endCol;
-                }
-                if (msg) {
-                  sub = {
-                    message: message,
-                    file: filePath,
-                    line: startLine,
-                    line_end: endLine,
-                    col: startCol,
-                    col_end: endCol,
-                    type: err.level2type(level),
-                    severity: err.level2severity(level)
-                  };
-                  msg.trace.push(sub);
-                }
-              }
-            } else {
-              // Check for panic
-              const parsedQty = panicParser.tryParsePanic(lines, i, panicsN < panicsLimit, buildWorkDir);
-              if (parsedQty > 0) {
-                msg = null;
-                sub = null;
-                i += parsedQty - 1; // Subtract one because the current line is already counted
-                panicsN += 1;
-              } else if (sub !== null) {
-                // Just a description in the current block. Only add it when in submessage
-                // because Linter does the job for high-level messages.
-                sub.message += '\n' + line;
-              }
+
+          // Try parse a standard output message
+          if (parsedQty == 0 && !useJson) {
+            parsedQty = stdParser.tryParseMessage(lines, i, messages);
+          }
+
+          // Try parse a panic
+          if (parsedQty == 0) {
+            parsedQty = panicParser.tryParsePanic(lines, i, panicsN < panicsLimit, buildWorkDir);
+            if (parsedQty > 0) {
+              panicsN += 1;
             }
+          }
+
+          if (parsedQty > 1) {
+            i += parsedQty - 1; // Subtract one because the current line is already counted
           }
         }
         const hiddenPanicsN = panicsN - panicsLimit;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,7 +5,136 @@
 //
 
 const notificationCfg = { dismissable: true };
-const abortRegex = /aborting due to (\d+ )?previous error[s]?/;
+
+// Meta errors are ignored
+const metaErrors = [
+  /aborting due to (\d+ )?previous error[s]?/,
+  /Could not compile `.+`./
+];
+
+// Collection of span labels that must be ignored (not added to the main message)
+// because the main message already contains the same information
+const redundantLabels = [{
+  // E0001
+  label: /this is an unreachable pattern/,
+  message: /unreachable pattern/
+}, {
+  // E0004
+  label: /pattern `.+` not covered/,
+  message: /non-exhaustive patterns: `.+` not covered/
+}, {
+  // E00023
+  label: /expected \d+ field[s]?, found \d+/,
+  message: /this pattern has \d+ field[s]?, but the corresponding variant has \d+ field[s]?/
+}, {
+  // E0026
+  label: /struct `.+` does not have field `.+`/,
+  message: /struct `.+` does not have a field named `.+`/
+}, {
+  // E0027
+  label: /missing field `.+`/,
+  message: /pattern does not mention field `.+`/
+}, {
+  // E0029
+  label: /ranges require char or numeric types/,
+  message: /only char and numeric types are allowed in range patterns/
+}, {
+  // E0040
+  label: /call to destructor method/,
+  message: /explicit use of destructor method/
+}, {
+  // E0046
+  label: /missing `.+` in implementation/,
+  message: /not all trait items implemented, missing: `.+`/
+}, {
+  // E0057
+  label: /expected \d+ parameter[s]?/,
+  message: /this function takes \d+ parameter[s]? but \d+ parameter[s]? (was|were) supplied/
+}, {
+  // E0062
+  label: /used more than once/,
+  message: /field `.+` specified more than once/
+}, {
+  // E0067
+  label: /invalid expression for left-hand side/,
+  message: /invalid left-hand side expression/
+}, {
+  // E0068
+  label: /return type is not \(\)/,
+  message: /`return;` in a function whose return type is not `\(\)`/
+}, {
+  // E0071
+  label: /not a struct/,
+  message: /`.+` does not name a struct or a struct variant/
+}, {
+  // E0072
+  label: /recursive type has infinite size/,
+  message: /recursive type `.+` has infinite size/
+}, {
+  // E0087
+  label: /expected \d+ parameter[s]?/,
+  message: /too many type parameters provided: expected at most \d+ parameter[s]?, found \d+ parameter[s]?/
+}, {
+  // E0091
+  label: /unused type parameter/,
+  message: /type parameter `.+` is unused/
+}, {
+  // E0101
+  label: /cannot resolve type of expression/,
+  message: /cannot determine a type for this expression: unconstrained type/
+}, {
+  // E0102
+  label: /cannot resolve type of variable/,
+  message: /cannot determine a type for this local variable: unconstrained type/
+}, {
+  // E0106
+  label: /expected lifetime parameter/,
+  message: /missing lifetime specifier/
+}, {
+  // E0107
+  label: /(un)?expected (\d+ )?lifetime parameter[s]?/,
+  message: /wrong number of lifetime parameters: expected \d+, found \d+/
+}, {
+  // E0109
+  label: /type parameter not allowed/,
+  message: /type parameters are not allowed on this type/
+}, {
+  // E0110
+  label: /lifetime parameter not allowed/,
+  message: /lifetime parameters are not allowed on this type/
+}, {
+  // E0116
+  label: /impl for type defined outside of crate/,
+  message: /cannot define inherent `.+` for a type outside of the crate where the type is defined/
+}, {
+  // E0117
+  label: /impl doesn't use types inside crate/,
+  message: /only traits defined in the current crate can be implemented for arbitrary types/
+}, {
+  // E0119
+  label: /conflicting implementation for `.+`/,
+  message: /conflicting implementations of trait `.+` for type `.+`/
+}, {
+  // E0120
+  label: /implementing Drop requires a struct/,
+  message: /the Drop trait may only be implemented on structures/
+}, {
+  // E0121
+  label: /not allowed in type signatures/,
+  message: /the type placeholder `_` is not allowed within types on item signatures/
+}, {
+  // E0124
+  label: /field already declared/,
+  message: /field `.+` is already declared/
+}, {
+  // E0368
+  label: /cannot use `[<>+&|^\-]?=` on type `.+`/,
+  message: /binary assignment operation `[<>+&|^\-]?=` cannot be applied to type `.+`/
+}, {
+  // E0387
+  label: /cannot borrow mutably/,
+  message: /cannot borrow immutable local variable `.+` as mutable/
+}];
 
 const level2severity = (level) => {
   switch (level) {
@@ -21,25 +150,107 @@ const level2type = (level) => {
   return level.charAt(0).toUpperCase() + level.slice(1);
 };
 
+// Appends a span label to the main message if it's not redundant.
+function appendSpanLabel(msg) {
+  if (msg.extra.spanLabel && msg.extra.spanLabel.length > 0) {
+    const label = msg.extra.spanLabel;
+    if (msg.message.indexOf(label) >= 0) {
+      return;      // Label is contained within the main message
+    }
+    for (let i = 0; i < redundantLabels.length; i++) {
+      const l = redundantLabels[i];
+      if (l.label.test(label) && l.message.test(msg.message)) {
+        return;    // Submesage fits one of the deduplication patterns
+      }
+    }
+    msg.message += ' (' + label + ')';
+  }
+}
+
+// Adds the error code to the message
+function appendErrorCode(msg) {
+  if (msg.extra.errorCode && msg.extra.errorCode.length > 0) {
+    msg.message += ' [' + msg.extra.errorCode + ']';
+  }
+}
+
+// Adds an extra info (if provided) to the message.
+// Deletes the extra info after extracting.
+function appendExtraInfo(msg) {
+  if (msg.extra) {
+    appendSpanLabel(msg);
+    appendErrorCode(msg);
+    delete msg.extra;
+  }
+}
+
+// Checks if the location of the given message is valid
+function isValidLocation(msg) {
+  return msg.file && !msg.file.startsWith('<');
+}
+
+// Removes location info from the given message
+function removeLocation(msg) {
+  delete msg.file;
+  delete msg.line;
+  delete msg.line_end;
+  delete msg.col;
+  delete msg.col_end;
+}
+
+// Copies location info from one message to another
+function copyLocation(fromMsg, toMsg) {
+  toMsg.file = fromMsg.file;
+  toMsg.line = fromMsg.line;
+  toMsg.line_end = fromMsg.line_end;
+  toMsg.col = fromMsg.col;
+  toMsg.col_end = fromMsg.col_end;
+}
+
+// Removes location info from the submessage if it's exactly the same as in
+// the main message.
+// Fixes locations that don't point to a valid source code.
+// Example: <std macros>:1:33: 1:60
+function normalizeLocations(msg) {
+  for(let i = 0; i < msg.trace.length; i++) {
+    const subMsg = msg.trace[i];
+    // Deduplicate location
+    if (!isValidLocation(subMsg) || (subMsg.file === msg.file && subMsg.line === msg.line && subMsg.col === msg.col)) {
+      removeLocation(subMsg);
+    }
+    if (!isValidLocation(msg) && isValidLocation(subMsg)) {
+      copyLocation(subMsg, msg);
+      removeLocation(subMsg);
+    }
+  }
+}
+
 // Set location for special cases when the compiler doesn't provide it
 function preprocessMessage(msg, buildWorkDir) {
-  if (msg.file) {
+  appendExtraInfo(msg);
+  normalizeLocations(msg);
+  // Check if the message can be added to Linter
+  if (isValidLocation(msg)) {
     return true;
   }
-  if (!abortRegex.test(msg.message)) { // This meta error is ignored
-    // Location is not provided for the message, so it cannot be added to Linter.
-    // Display it as a notification.
-    switch (msg.level) {
-      case 'info':
-      case 'note':
-        atom.notifications.addInfo(msg.message, notificationCfg);
-        break;
-      case 'warning':
-        atom.notifications.addWarning(msg.message, notificationCfg);
-        break;
-      default:
-        atom.notifications.addError(msg.message, notificationCfg);
+  // Ignore meta errors
+  for (let i = 0; i < metaErrors.length; i++) {
+    if (metaErrors[i].test(msg.message)) {
+      return false;
     }
+  }
+  // Location is not provided for the message, so it cannot be added to Linter.
+  // Display it as a notification.
+  switch (msg.level) {
+    case 'info':
+    case 'note':
+      atom.notifications.addInfo(msg.message, notificationCfg);
+      break;
+    case 'warning':
+      atom.notifications.addWarning(msg.message, notificationCfg);
+      break;
+    default:
+      atom.notifications.addError(msg.message, notificationCfg);
   }
   return false;
 }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -212,7 +212,7 @@ function copyLocation(fromMsg, toMsg) {
 // Fixes locations that don't point to a valid source code.
 // Example: <std macros>:1:33: 1:60
 function normalizeLocations(msg) {
-  for(let i = 0; i < msg.trace.length; i++) {
+  for (let i = 0; i < msg.trace.length; i++) {
     const subMsg = msg.trace[i];
     // Deduplicate location
     if (!isValidLocation(subMsg) || (subMsg.file === msg.file && subMsg.line === msg.line && subMsg.col === msg.col)) {

--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -15,22 +15,6 @@ function copySpanLocation(span, msg) {
   msg.col_end = span.column_end;
 }
 
-// Appends spans's label to the main message. It only adds the label if:
-// - the main message doesn't contain exactly the same phrase
-// - the main message doesn't contain the same information but uses different wording
-function appendSpanLabel(span, msg) {
-  if (!span.label || msg.message.indexOf(span.label) >= 0) {
-    return;
-  }
-  for (let idx = 0; idx < redundantLabels.length; idx++) {
-    const l = redundantLabels[idx];
-    if (l.label.test(span.label) && l.message.test(msg.message)) {
-      return;
-    }
-  }
-  msg.message += ' (' + span.label + ')';
-}
-
 function parseSpan(span, msg, mainMsg) {
   if (span.is_primary) {
     msg.extra.spanLabel = span.label;

--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -6,130 +6,6 @@
 
 const err = require('./errors');
 
-// Collection of span labels that must be ignored (not added to the main message)
-// because the main message already contains the same information
-const redundantLabels = [{
-  // E0001
-  label: /this is an unreachable pattern/,
-  message: /unreachable pattern/
-}, {
-  // E0004
-  label: /pattern `.+` not covered/,
-  message: /non-exhaustive patterns: `.+` not covered/
-}, {
-  // E00023
-  label: /expected \d+ fields, found \d+/,
-  message: /this pattern has \d+ field, but the corresponding variant has \d+ fields/
-}, {
-  // E0026
-  label: /struct `.+` does not have field `.+`/,
-  message: /struct `.+` does not have a field named `.+`/
-}, {
-  // E0027
-  label: /missing field `.+`/,
-  message: /pattern does not mention field `.+`/
-}, {
-  // E0029
-  label: /ranges require char or numeric types/,
-  message: /only char and numeric types are allowed in range patterns/
-}, {
-  // E0040
-  label: /call to destructor method/,
-  message: /explicit use of destructor method/
-}, {
-  // E0046
-  label: /missing `.+` in implementation/,
-  message: /not all trait items implemented, missing: `.+`/
-}, {
-  // E0057
-  label: /expected \d+ parameter[s]?/,
-  message: /this function takes \d+ parameter[s]? but \d+ parameter[s]? (was|were) supplied/
-}, {
-  // E0062
-  label: /used more than once/,
-  message: /field `.+` specified more than once/
-}, {
-  // E0067
-  label: /invalid expression for left-hand side/,
-  message: /invalid left-hand side expression/
-}, {
-  // E0068
-  label: /return type is not \(\)/,
-  message: /`return;` in a function whose return type is not `\(\)`/
-}, {
-  // E0071
-  label: /not a struct/,
-  message: /`.+` does not name a struct or a struct variant/
-}, {
-  // E0072
-  label: /recursive type has infinite size/,
-  message: /recursive type `.+` has infinite size/
-}, {
-  // E0087
-  label: /expected \d+ parameter[s]?/,
-  message: /too many type parameters provided: expected at most \d+ parameter[s]?, found \d+ parameter[s]?/
-}, {
-  // E0091
-  label: /unused type parameter/,
-  message: /type parameter `.+` is unused/
-}, {
-  // E0101
-  label: /cannot resolve type of expression/,
-  message: /cannot determine a type for this expression: unconstrained type/
-}, {
-  // E0102
-  label: /cannot resolve type of variable/,
-  message: /cannot determine a type for this local variable: unconstrained type/
-}, {
-  // E0106
-  label: /expected lifetime parameter/,
-  message: /missing lifetime specifier/
-}, {
-  // E0107
-  label: /(un)?expected (\d+ )?lifetime parameter[s]?/,
-  message: /wrong number of lifetime parameters: expected \d+, found \d+/
-}, {
-  // E0109
-  label: /type parameter not allowed/,
-  message: /type parameters are not allowed on this type/
-}, {
-  // E0110
-  label: /lifetime parameter not allowed/,
-  message: /lifetime parameters are not allowed on this type/
-}, {
-  // E0116
-  label: /impl for type defined outside of crate/,
-  message: /cannot define inherent `.+` for a type outside of the crate where the type is defined/
-}, {
-  // E0117
-  label: /impl doesn't use types inside crate/,
-  message: /only traits defined in the current crate can be implemented for arbitrary types/
-}, {
-  // E0119
-  label: /conflicting implementation for `.+`/,
-  message: /conflicting implementations of trait `.+` for type `.+`/
-}, {
-  // E0120
-  label: /implementing Drop requires a struct/,
-  message: /the Drop trait may only be implemented on structures/
-}, {
-  // E0121
-  label: /not allowed in type signatures/,
-  message: /the type placeholder `_` is not allowed within types on item signatures/
-}, {
-  // E0124
-  label: /field already declared/,
-  message: /field `.+` is already declared/
-}, {
-  // E0368
-  label: /cannot use `[<>+&|^\-]?=` on type `.+`/,
-  message: /binary assignment operation `[<>+&|^\-]?=` cannot be applied to type `.+`/
-}, {
-  // E0387
-  label: /cannot borrow mutably/,
-  message: /cannot borrow immutable local variable `.+` as mutable/
-}];
-
 // Copies a location from the given span to a linter message
 function copySpanLocation(span, msg) {
   msg.file = span.file_name;
@@ -137,16 +13,6 @@ function copySpanLocation(span, msg) {
   msg.line_end = span.line_end;
   msg.col = span.column_start;
   msg.col_end = span.column_end;
-}
-
-// Checks if the location of the given span is the same as the location
-// of the given message
-function compareLocations(span, msg) {
-  return span.file_name === msg.file
-    && span.line_start === msg.line
-    && span.line_end === msg.line_end
-    && span.column_start === msg.col
-    && span.column_end === msg.col_end;
 }
 
 // Appends spans's label to the main message. It only adds the label if:
@@ -167,13 +33,14 @@ function appendSpanLabel(span, msg) {
 
 function parseSpan(span, msg, mainMsg) {
   if (span.is_primary) {
-    appendSpanLabel(span, msg);
+    msg.extra.spanLabel = span.label;
     // If the error is within a macro, add the macro text to the message
     if (span.file_name && span.file_name.startsWith('<') && span.text && span.text.length > 0) {
       msg.trace.push({
         message: span.text[0].text,
         type: 'Macro',
-        severity: 'info'
+        severity: 'info',
+        extra: {}
       });
     }
   }
@@ -183,21 +50,16 @@ function parseSpan(span, msg, mainMsg) {
       const trace = {
         message: span.label,
         type: 'Note',
-        severity: 'info'
+        severity: 'info',
+        extra: {}
       };
-      // Add location only if it's not the same as in the primary span
-      // or if the primary span is unknown at this point
-      if (!compareLocations(span, mainMsg)) {
-        copySpanLocation(span, trace);
-      }
+      copySpanLocation(span, trace);
       msg.trace.push(trace);
     }
     // Copy the main error location from the primary span or from any other
     // span if it hasn't been defined yet
     if (span.is_primary || !msg.file) {
-      if (!compareLocations(span, mainMsg)) {
-        copySpanLocation(span, msg);
-      }
+      copySpanLocation(span, msg);
     }
     return true;
   } else if (span.expansion) {
@@ -220,27 +82,28 @@ const parseMessage = (line, messages) => {
     message: json.message,
     type: err.level2type(json.level),
     severity: err.level2severity(json.level),
-    trace: []
+    trace: [],
+    extra: {}
   };
   parseSpans(json, msg, msg);
   json.children.forEach(child => {
     const tr = {
       message: child.message,
       type: err.level2type(child.level),
-      severity: err.level2severity(child.level)
+      severity: err.level2severity(child.level),
+      extra: {}
     };
     parseSpans(child, tr, msg);
     msg.trace.push(tr);
   });
   if (json.code) {
-    if (json.code.code) {
-      msg.message += ' [' + json.code.code + ']';
-    }
+    msg.extra.errorCode = json.code.code;
     if (json.code.explanation) {
       msg.trace.push({
         message: json.code.explanation,
         type: 'Explanation',
-        severity: 'info'
+        severity: 'info',
+        extra: {}
       });
     }
   }

--- a/lib/std-parser.js
+++ b/lib/std-parser.js
@@ -111,7 +111,7 @@ function parseMessageHeader(lines, i) {
 function parseCodeBlock(lines, i, msg) {
   let l = i;
   let spanLineNo = -1;
-  while(l < lines.length && lines[l] != '') {
+  while(l < lines.length && lines[l] !== '') {
     const line = lines[l];
     let lineParsed = false;
     const codeMatch = /^\s*(\d*)\s*\|.*/.exec(line);

--- a/lib/std-parser.js
+++ b/lib/std-parser.js
@@ -1,0 +1,217 @@
+'use babel';
+
+//
+// Standard error format parser.
+//
+
+const err = require('./errors');
+
+// Detects message headers (the main message and location):
+//
+// Examles:
+//
+// error[E0023]: Some error message
+//   --> src/main.rs:157:12
+//
+// <std macros>:1:33: 1:58 Some message
+//
+// src/main.rs:157:12: 157:18 Some message
+//
+// error: Something happened
+//
+// Retursn the message infromation and the number of parsed lines.
+function parseMessageHeader(lines, i) {
+  let l = i;
+  const match = /^(error|warning|note|help)(?:\[(E\d+)\])?: (.*)/.exec(lines[l]);
+  if (match) {
+    const level = match[1];
+    const code = match[2];
+    const message = match[3];
+    if (lines.length >= i) {
+      const locMatch = /^\s*--> (.+):(\d+):(\d+)/.exec(lines[l + 1]);
+      if (locMatch) {
+        const locFile = locMatch[1];
+        const locLine = parseInt(locMatch[2]);
+        const locColStart = parseInt(locMatch[3]);
+        const msg = {
+          message: message,
+          type: err.level2type(level),
+          severity: err.level2severity(level),
+          file: locFile,
+          line: locLine,
+          line_end: locLine,
+          col: locColStart,
+          col_end: locColStart + 1,  // Highlight only one symbol by default
+          trace: [],
+          extra: {
+            errorCode: code
+          }
+        };
+        return {
+          message: msg,
+          parsedQty: 2    // Number of parsed lines
+        };
+      }
+    }
+  }
+
+  // Try the format that is usually found in errors within macros:
+  // file_name:l:c: le:ce: message
+  const macroMatch = /^\s*(.+):(\d+):(\d+): (\d+):(\d+) (error|warning|note|help):\s*(.*)/.exec(lines[l]);
+  if (macroMatch) {
+    const msg = {
+      message: macroMatch[7],
+      type: err.level2type(macroMatch[6]),
+      severity: err.level2severity(macroMatch[6]),
+      file: macroMatch[1],
+      line: parseInt(macroMatch[2]),
+      line_end: parseInt(macroMatch[4]),
+      col: parseInt(macroMatch[3]),
+      col_end: parseInt(macroMatch[5]),
+      trace: [],
+      extra: {}
+    };
+    return {
+      message: msg,
+      parsedQty: 1    // Number of parsed lines
+    };
+  }
+
+  // Try the simplest format:
+  // error: message
+  const simpleMatch = /^\s*(error|warning|note|help):\s*(.*)/.exec(lines[l]);
+  if (simpleMatch) {
+    const msg = {
+      message: simpleMatch[2],
+      type: err.level2type(simpleMatch[1]),
+      severity: err.level2severity(simpleMatch[1]),
+      trace: [],
+      extra: {}
+    };
+    return {
+      message: msg,
+      parsedQty: 1    // Number of parsed lines
+    };
+  }
+
+  return undefined;
+}
+
+// Parses a code block. If a message provided, extracts the additional info (the span length,
+// the additional text etc) from the block and modifies the message info accordingly.
+//
+// Examle:
+//
+//    |
+// 12 |    some code here
+//    |         ^^^^ additional text
+//    = note: additional note
+//
+// Returns the number of parsed lines.
+function parseCodeBlock(lines, i, msg) {
+  let l = i;
+  let spanLineNo = -1;
+  while(l < lines.length && lines[l] != '') {
+    const line = lines[l];
+    let lineParsed = false;
+    const codeMatch = /^\s*(\d*)\s*\|.*/.exec(line);
+    if (codeMatch) {
+      if (codeMatch[1].length > 0) {
+        spanLineNo = parseInt(codeMatch[1]);
+      } else {
+        const spanMatch = /^[\s\d]*\|(\s+)([\^-]+)\s*(.*)/.exec(line);
+        if (spanMatch) {
+          // The line contains span highlight
+          const startCol = spanMatch[1].length;
+          const light = spanMatch[2];
+          const label = spanMatch[3].length > 0 ? spanMatch[3] : undefined;
+          if (light[0] === '^') {
+            // It's the primary span. Copy the highlighting infro to the main message
+            msg.col_end = msg.col + light.length;
+            msg.extra.spanLabel = label;
+          } else if (light[0] == '-' && label) {
+            // It's a secondary span, create a submessage
+            msg.trace.push({
+              message: label,
+              type: 'Note',
+              severity: 'info',
+              file: msg.file,
+              line: spanLineNo,
+              line_end: spanLineNo,
+              col: startCol,
+              col_end: startCol + light.length,
+              extra: {}
+            });
+          }
+        }
+      }
+      lineParsed = true;
+    } else {
+      const auxMatch = /^\s*= (note|help): (.+)/.exec(line);
+      if (auxMatch) {
+        msg.trace.push({
+          message: auxMatch[2],
+          type: err.level2type(auxMatch[1]),
+          severity: err.level2severity(auxMatch[1]),
+          extra: {}
+        });
+        lineParsed = true;
+      }
+    }
+    if (!lineParsed && line.startsWith('...')) {  // Gaps in the source code are displayed this way
+      lineParsed = true;
+    }
+    // TODO: Backward compatibility with Rust prior to 1.12. Remove this if-block when there's no need to support it.
+    if (!lineParsed && (/^[^:]*:(\d+)\s+.*/.test(line) || /^\s+\^.*/.test(line))) {
+      lineParsed = true;
+    }
+    if (lineParsed) {
+      l += 1;
+    } else {
+      break;
+    }
+  }
+
+  return l - i;
+}
+
+function parseMessageBlock(lines, i, messages, parentMsg) {
+  let l = i;
+  let headerInfo = parseMessageHeader(lines, i);
+  if (headerInfo) {
+    // TODO: Backward compatibility with Rust prior to 1.12. Remove this if-block when there's no need to support it.
+    if ((parentMsg && (headerInfo.message.severity === 'error' || headerInfo.message.severity === 'warning'))
+        || (!parentMsg && headerInfo.message.severity !== 'error' && headerInfo.message.severity !== 'warning')) {
+      return 0;
+    }
+    // Message header detected, remember it and continue parsing
+    l += headerInfo.parsedQty;
+    if (parentMsg) {
+      // We are parsing a submessage, add it to trace
+      parentMsg.trace.push(headerInfo.message);
+    } else {
+      // We are parsing the main message
+      messages.push(headerInfo.message);
+    }
+    l += parseCodeBlock(lines, l, headerInfo.message);
+    // If it's the main message, parse its submessages
+    if (!parentMsg) {
+      while(true) {
+        const subParsedQty = parseMessageBlock(lines, l, messages, headerInfo.message);
+        if (subParsedQty > 0) {
+          l += subParsedQty;
+        } else {
+          break;
+        }
+      }
+    }
+  }
+
+  return l - i;
+}
+
+const tryParseMessage = (lines, i, messages) => {
+  return parseMessageBlock(lines, i, messages, null);
+};
+
+export { tryParseMessage };

--- a/lib/std-parser.js
+++ b/lib/std-parser.js
@@ -21,18 +21,17 @@ const err = require('./errors');
 //
 // Retursn the message infromation and the number of parsed lines.
 function parseMessageHeader(lines, i) {
-  let l = i;
-  const match = /^(error|warning|note|help)(?:\[(E\d+)\])?: (.*)/.exec(lines[l]);
+  const match = /^(error|warning|note|help)(?:\[(E\d+)\])?: (.*)/.exec(lines[i]);
   if (match) {
     const level = match[1];
     const code = match[2];
     const message = match[3];
     if (lines.length >= i) {
-      const locMatch = /^\s*--> (.+):(\d+):(\d+)/.exec(lines[l + 1]);
+      const locMatch = /^\s*--> (.+):(\d+):(\d+)/.exec(lines[i + 1]);
       if (locMatch) {
         const locFile = locMatch[1];
-        const locLine = parseInt(locMatch[2]);
-        const locColStart = parseInt(locMatch[3]);
+        const locLine = parseInt(locMatch[2], 10);
+        const locColStart = parseInt(locMatch[3], 10);
         const msg = {
           message: message,
           type: err.level2type(level),
@@ -57,17 +56,17 @@ function parseMessageHeader(lines, i) {
 
   // Try the format that is usually found in errors within macros:
   // file_name:l:c: le:ce: message
-  const macroMatch = /^\s*(.+):(\d+):(\d+): (\d+):(\d+) (error|warning|note|help):\s*(.*)/.exec(lines[l]);
+  const macroMatch = /^\s*(.+):(\d+):(\d+): (\d+):(\d+) (error|warning|note|help):\s*(.*)/.exec(lines[i]);
   if (macroMatch) {
     const msg = {
       message: macroMatch[7],
       type: err.level2type(macroMatch[6]),
       severity: err.level2severity(macroMatch[6]),
       file: macroMatch[1],
-      line: parseInt(macroMatch[2]),
-      line_end: parseInt(macroMatch[4]),
-      col: parseInt(macroMatch[3]),
-      col_end: parseInt(macroMatch[5]),
+      line: parseInt(macroMatch[2], 10),
+      line_end: parseInt(macroMatch[4], 10),
+      col: parseInt(macroMatch[3], 10),
+      col_end: parseInt(macroMatch[5], 10),
       trace: [],
       extra: {}
     };
@@ -79,7 +78,7 @@ function parseMessageHeader(lines, i) {
 
   // Try the simplest format:
   // error: message
-  const simpleMatch = /^\s*(error|warning|note|help):\s*(.*)/.exec(lines[l]);
+  const simpleMatch = /^\s*(error|warning|note|help):\s*(.*)/.exec(lines[i]);
   if (simpleMatch) {
     const msg = {
       message: simpleMatch[2],
@@ -111,13 +110,13 @@ function parseMessageHeader(lines, i) {
 function parseCodeBlock(lines, i, msg) {
   let l = i;
   let spanLineNo = -1;
-  while(l < lines.length && lines[l] !== '') {
+  while (l < lines.length && lines[l] !== '') {
     const line = lines[l];
     let lineParsed = false;
     const codeMatch = /^\s*(\d*)\s*\|.*/.exec(line);
     if (codeMatch) {
       if (codeMatch[1].length > 0) {
-        spanLineNo = parseInt(codeMatch[1]);
+        spanLineNo = parseInt(codeMatch[1], 10);
       } else {
         const spanMatch = /^[\s\d]*\|(\s+)([\^-]+)\s*(.*)/.exec(line);
         if (spanMatch) {
@@ -129,7 +128,7 @@ function parseCodeBlock(lines, i, msg) {
             // It's the primary span. Copy the highlighting infro to the main message
             msg.col_end = msg.col + light.length;
             msg.extra.spanLabel = label;
-          } else if (light[0] == '-' && label) {
+          } else if (light[0] === '-' && label) {
             // It's a secondary span, create a submessage
             msg.trace.push({
               message: label,
@@ -177,7 +176,7 @@ function parseCodeBlock(lines, i, msg) {
 
 function parseMessageBlock(lines, i, messages, parentMsg) {
   let l = i;
-  let headerInfo = parseMessageHeader(lines, i);
+  const headerInfo = parseMessageHeader(lines, i);
   if (headerInfo) {
     // TODO: Backward compatibility with Rust prior to 1.12. Remove this if-block when there's no need to support it.
     if ((parentMsg && (headerInfo.message.severity === 'error' || headerInfo.message.severity === 'warning'))
@@ -196,7 +195,7 @@ function parseMessageBlock(lines, i, messages, parentMsg) {
     l += parseCodeBlock(lines, l, headerInfo.message);
     // If it's the main message, parse its submessages
     if (!parentMsg) {
-      while(true) {
+      while (l < lines.length) {
         const subParsedQty = parseMessageBlock(lines, l, messages, headerInfo.message);
         if (subParsedQty > 0) {
           l += subParsedQty;


### PR DESCRIPTION
I've implemented the new error format support.

It extracts all possible information from error messages and code snippets. The only known problem is that it cannot parse all the spans when several of them are placed on a single line of code with overlapping, for example:

```
error[E0062]: field `x` specified more than once
   --> src/main.rs:207:25
    |
207 |     let x = Foo { x: 0, x: 0 };
    |                   ----  ^ used more than once
    |                   |    
    |                   first use of `x`
```

In this error, the parser won't extract the information about the first use of `x`. Though, in vast majority of cases Rust separates such spans into different messages and it works well.

New parser is also capable of parsing the old error format, though minor problems exist with multiline messages. I only remember one such message E0053, but there may be others:

```
src/main.rs:185:9: 185:27 error: method `foo` has an incompatible type for trait:
 expected u16,
    found i16 [E0053]
```

In such cases, only the first line is displayed to the user ("method `foo` has an incompatible type for trait").

I've also moved lots of code from the JSON parser to `errors.js`, so all the errors are handled in the same manner (messages format, label deduplication, correct location searching, etc) independently of the parser type. So, parsers only supply raw data to the `preprocessMessage()` function which does all the job to make them look neat.
