### PR TITLE
[breaking change] use cargo --message-format for generating json errors

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -204,7 +204,7 @@ export function provideBuilder() {
         buildCfg.exec = atom.config.get('build-cargo.cargoPath');
         buildCfg.env = {};
         if (atom.config.get('build-cargo.jsonErrorFormat')) {
-          buildCfg.args.push("--message-format=json");
+          buildCfg.args.push('--message-format=json');
         } else if (process.platform !== 'win32') {
           buildCfg.env.TERM = 'xterm';
           buildCfg.env.RUSTFLAGS = '--color=always';

--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -204,7 +204,7 @@ export function provideBuilder() {
         buildCfg.exec = atom.config.get('build-cargo.cargoPath');
         buildCfg.env = {};
         if (atom.config.get('build-cargo.jsonErrorFormat')) {
-          buildCfg.env.RUSTFLAGS = '-Z unstable-options --error-format=json';
+          buildCfg.args.push("--message-format=json");
         } else if (process.platform !== 'win32') {
           buildCfg.env.TERM = 'xterm';
           buildCfg.env.RUSTFLAGS = '--color=always';

--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -61,7 +61,7 @@ function parseSpans(jsonObj, msg, mainMsg) {
 
 // Parses a compile message in the JSON format
 const parseMessage = (line, messages) => {
-  const json = JSON.parse(line);
+  const json = JSON.parse(line).message;
   const msg = {
     message: json.message,
     type: err.level2type(json.level),


### PR DESCRIPTION
fixes #65

we can simply do a major version bump and nothing should break for ppl who didn't update their cargo (I hope atom does semantic versioning).

cc @excaliburHisSheath

r? @alygin 