### PR TITLE
Display error explanations in html format

### DIFF
--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -6,6 +6,8 @@
 
 const err = require('./errors');
 
+import marked from 'marked';
+
 // Copies a location from the given span to a linter message
 function copySpanLocation(span, msg) {
   msg.file = span.file_name;
@@ -84,7 +86,7 @@ const parseMessage = (line, messages) => {
     msg.extra.errorCode = json.code.code;
     if (json.code.explanation) {
       msg.trace.push({
-        message: json.code.explanation,
+        html_message: '<details><summary>Expand to see the detailed explanation</summary>' + marked(json.code.explanation) + '</details>',
         type: 'Explanation',
         severity: 'info',
         extra: {}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
       }
     }
   },
+  "dependencies": {
+    "marked": "^0.3.6"
+  },
   "devDependencies": {
     "babel-eslint": "^6.0.0",
     "eslint": "^2.5.3",


### PR DESCRIPTION
This PR leverages [html_message field support](https://github.com/noseglid/atom-build/issues/428) and the [marked library](https://github.com/chjj/marked) to properly format error explanations:

<img width="820" alt="screen shot 2016-11-19 at 21 45 19" src="https://cloud.githubusercontent.com/assets/2101250/20457686/7f3a5464-aea1-11e6-8c01-c8e2bcbc116e.png">

It brings a dependency to the package and I don't know if it's ok to just declare it in the `package.json` or something else must be done? 

@oli-obk, I remember you wanted to have such a feature. What do you think about this implementation?
