### PR TITLE
Fixed parsing of JSON with nested children

### DIFF
--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -77,6 +77,7 @@ const parseMessage = (line, messages) => {
       message: child.message,
       type: err.level2type(child.level),
       severity: err.level2severity(child.level),
+      trace: [],
       extra: {}
     };
     parseSpans(child, tr, msg);


### PR DESCRIPTION
Presumably, fixes #69

@oli-obk, I found the potential problem, but cannot reproduce the error. Could you, please, check this fix on your code?