### PR TITLE
Error explanation links in std output mode

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -229,6 +229,14 @@ function normalizeLocations(msg) {
 function preprocessMessage(msg, buildWorkDir) {
   appendExtraInfo(msg);
   normalizeLocations(msg);
+  // Reorder trace items if needed.
+  // Not explicitly ordered items always go first in their original order.
+  msg.trace.sort(function(a, b) {
+    if (!a.order && b.order) {
+      return -1;
+    }
+    return a.order && b.order ? a.order - b.order : 1 }
+  );
   // Check if the message can be added to Linter
   if (isValidLocation(msg)) {
     return true;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -231,12 +231,12 @@ function preprocessMessage(msg, buildWorkDir) {
   normalizeLocations(msg);
   // Reorder trace items if needed.
   // Not explicitly ordered items always go first in their original order.
-  msg.trace.sort(function(a, b) {
+  msg.trace.sort(function (a, b) {
     if (!a.order && b.order) {
       return -1;
     }
-    return a.order && b.order ? a.order - b.order : 1 }
-  );
+    return a.order && b.order ? a.order - b.order : 1;
+  });
   // Check if the message can be added to Linter
   if (isValidLocation(msg)) {
     return true;

--- a/lib/std-parser.js
+++ b/lib/std-parser.js
@@ -46,6 +46,15 @@ function parseMessageHeader(lines, i) {
             errorCode: code
           }
         };
+        if (code && code.length > 0) {
+          msg.trace.push({
+            html_message: '<a href="https://doc.rust-lang.org/error-index.html#' + msg.extra.errorCode + '">Explain error ' + code + '</a>',
+            type: 'Explanation',
+            severity: 'info',
+            extra: {},
+            order: 100 // Always put it to the end of the list
+          });
+        }
         return {
           message: msg,
           parsedQty: 2    // Number of parsed lines


### PR DESCRIPTION
When using the standard error output mode, the user cannot quickly see the error explanations. This fix adds a new trace element that allows to quickly jump to the error explanation on the Rust error index page:

<img width="748" alt="screen shot 2016-11-24 at 10 38 26" src="https://cloud.githubusercontent.com/assets/2101250/20590578/04628666-b235-11e6-8849-d18b15fb47be.png">

The link is not added when the JSON output mode is activated since it already has the explanation block.

r? @oli-obk