### PR TITLE
Ignore Cargo general messages

### DIFF
--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -64,7 +64,7 @@ function parseSpans(jsonObj, msg, mainMsg) {
 // Parses a compile message in the JSON format
 const parseMessage = (line, messages) => {
   const json = JSON.parse(line).message;
-  if (!json.level) {
+  if (!json || !json.level) {
     // It's a cargo general message, not a compiler's one. Skip it.
     // In the future can be changed to "reason !== 'compiler-message'"
     return;

--- a/lib/json-parser.js
+++ b/lib/json-parser.js
@@ -64,6 +64,11 @@ function parseSpans(jsonObj, msg, mainMsg) {
 // Parses a compile message in the JSON format
 const parseMessage = (line, messages) => {
   const json = JSON.parse(line).message;
+  if (!json.level) {
+    // It's a cargo general message, not a compiler's one. Skip it.
+    // In the future can be changed to "reason !== 'compiler-message'"
+    return;
+  }
   const msg = {
     message: json.message,
     type: err.level2type(json.level),


### PR DESCRIPTION
In the verbose mode, Cargo repeats the compiler messages. It also emits its own general messages, like "aborting due to previous error". The fix makes the json-parser ignore such lines.

There's a proper field `reason` for separating rustc messages from Cargo's ones (rustc sets `reason=compiler-message`), but it's relatively young and might not work if someone still uses a previous Rust version. I think we can switch to using this field later. Until then, I think it's better to go with just checking the `level` presence.

r? @oli-obk 

Fixes #75