### PR TITLE
use cargo for passing `--color=always`

### DIFF
--- a/lib/cargo.js
+++ b/lib/cargo.js
@@ -208,7 +208,7 @@ export function provideBuilder() {
           buildCfg.args.push('--message-format=json');
         } else if (process.platform !== 'win32') {
           buildCfg.env.TERM = 'xterm';
-          buildCfg.env.RUSTFLAGS = '--color=always';
+          buildCfg.args.push('--color=always');
         }
         if (atom.config.get('build-cargo.backtraceType') !== 'Off') {
           buildCfg.env.RUST_BACKTRACE = '1';


### PR DESCRIPTION
fixes #65 (again)

works on my command line, not tested in atom or anything, but I don't see why it should fail.